### PR TITLE
Umsetzung der statistik-kompatiblen Navigation durch eine Ergebnisliste

### DIFF
--- a/modules/frontdoor/controllers/IndexController.php
+++ b/modules/frontdoor/controllers/IndexController.php
@@ -71,17 +71,18 @@ class Frontdoor_IndexController extends Application_Controller_Action {
             $queryResult = $resultList->getResults();
             if (is_array($queryResult) && !empty($queryResult) && $queryResult[0] instanceof Opus_Search_Result_Match) {
                 $resultDocId = $queryResult[0]->getId();
-
-                if (!$request->has('docId')) {
-                    $this->redirect($this->view->url(array('docId' => $resultDocId)));
-                }
-                if (!empty($docId)) {
-                    if ($resultDocId != $docId) {
-                        $this->view->messages = array('notice' => $this->view->translate('frontdoor_pagination_list_changed'));
+                $docIdDontMatch = !empty($docId) && $resultDocId != $docId;
+                if (!$request->has('docId') || $docIdDontMatch) {
+                    if ($docIdDontMatch) {
+                        $this->_helper->flashMessenger(array('notice' => $this->view->translate('frontdoor_pagination_list_changed')));
                     }
-                } else {
-                    $docId = $resultDocId;
+                    $this->redirect($this->view->url(array('docId' => $resultDocId)), array('prependBase' => false));
                 }
+                $docId = $resultDocId;
+            }
+            $messages = $this->_helper->flashMessenger->getMessages();
+            if (!empty($messages)) {
+                $this->view->messages = $messages[0];
             }
             $this->view->paginate = true;
             $numHits = $resultList->getNumberOfHits();

--- a/modules/frontdoor/controllers/IndexController.php
+++ b/modules/frontdoor/controllers/IndexController.php
@@ -64,13 +64,17 @@ class Frontdoor_IndexController extends Application_Controller_Action {
 
             $this->view->listRows = $listRows;
 
-            $request->setParam('rows', '1'); // make sure only 1 entry is diplayed
+            $request->setParam('rows', '1'); // make sure only 1 entry is displayed
             $query = Application_Search_Navigation::getQueryUrl($request, $this->getLogger());
             $searcher = new Opus_SolrSearch_Searcher();
             $resultList = $searcher->search($query);
             $queryResult = $resultList->getResults();
             if (is_array($queryResult) && !empty($queryResult) && $queryResult[0] instanceof Opus_Search_Result_Match) {
                 $resultDocId = $queryResult[0]->getId();
+
+                if (!$request->has('docId')) {
+                    $this->redirect($this->view->url(array('docId' => $resultDocId)));
+                }
                 if (!empty($docId)) {
                     if ($resultDocId != $docId) {
                         $this->view->messages = array('notice' => $this->view->translate('frontdoor_pagination_list_changed'));
@@ -78,19 +82,19 @@ class Frontdoor_IndexController extends Application_Controller_Action {
                 } else {
                     $docId = $resultDocId;
                 }
-                $this->view->paginate = true;
-                $numHits = $resultList->getNumberOfHits();
-                if ($request->getParam('searchtype') == 'latest') {
-                    $this->view->numOfHits = $numHits < $listRows ? $numHits : $listRows;
-                } else {
-                    $this->view->numOfHits = $numHits;
-                }
-                $this->view->searchPosition = $start;
-                $this->view->firstEntry = 0;
-                $this->view->lastEntry = $this->view->numOfHits - 1;
-                $this->view->previousEntry = ($this->view->searchPosition - 1) < 0 ? 0 : $this->view->searchPosition - 1;
-                $this->view->nextEntry = ($this->view->searchPosition + 1) < $this->view->numOfHits - 1 ? $this->view->searchPosition + 1 : $this->view->numOfHits - 1;
             }
+            $this->view->paginate = true;
+            $numHits = $resultList->getNumberOfHits();
+            if ($request->getParam('searchtype') == 'latest') {
+                $this->view->numOfHits = $numHits < $listRows ? $numHits : $listRows;
+            } else {
+                $this->view->numOfHits = $numHits;
+            }
+            $this->view->searchPosition = $start;
+            $this->view->firstEntry = 0;
+            $this->view->lastEntry = $this->view->numOfHits - 1;
+            $this->view->previousEntry = ($this->view->searchPosition - 1) < 0 ? 0 : $this->view->searchPosition - 1;
+            $this->view->nextEntry = ($this->view->searchPosition + 1) < $this->view->numOfHits - 1 ? $this->view->searchPosition + 1 : $this->view->numOfHits - 1;
         }
 
         if ($docId == '') {

--- a/modules/frontdoor/views/scripts/index/pagination.phtml
+++ b/modules/frontdoor/views/scripts/index/pagination.phtml
@@ -55,7 +55,7 @@
                 <?php if ($this->searchPosition == $this->firstEntry) : ?>
                     <div title="<?= $this->translate('pagination_previous_entry') ?>"></div>
                 <?php else: ?>
-                    <a title="<?= $this->translate('pagination_previous_entry') ?>" href="<?= $this->url(array('start' => $this->previousEntry, 'docId' => null)); ?>"></a>
+                    <a title="<?= $this->translate('pagination_previous_entry') ?>" href="<?= $this->url(array('start' => $this->previousEntry, 'nav' => 'prev', 'docId' => null)); ?>"></a>
                 <?php endif ?>
             </li>
 
@@ -63,7 +63,7 @@
                 <?php if ($this->searchPosition == $this->lastEntry) : ?>
                     <div title="<?= $this->translate('pagination_next_entry') ?>"></div>
                 <?php else: ?>
-                    <a title="<?= $this->translate('pagination_next_entry') ?>" href="<?= $this->url(array('start' => $this->nextEntry, 'docId' => null)); ?>"></a>
+                    <a title="<?= $this->translate('pagination_next_entry') ?>" href="<?= $this->url(array('start' => $this->nextEntry, 'nav' => 'next', 'docId' => null)); ?>"></a>
                 <?php endif ?>
             </li>
         </ul>
@@ -76,6 +76,7 @@
            'action' => 'search',
            'rows' => $this->listRows,
            'start' => floor(($this->searchPosition) / $this->listRows) * $this->listRows,
+           'nav' => null,
            'docId' => null
        ))
        ?>"><?= $this->translate('back_to_result_list') ?></a>


### PR DESCRIPTION
Es wird nun durch einen Redirect sichergestellt, dass au der Frontdoor in der aufgerufenen URL immer der Parameter "docId" vorhanden ist. Wird von einem Treffer zum nächsten bzw. vorherigen navigiert, ist nun auch der Parameter "nav" mit den entsprechenden Werten "next" bzw. "prev" vorhanden.