### PR TITLE
Entfernung der Leerzeichen in den CollectionRole-Attributen display_browsing bzw. display_frontdoor

### DIFF
--- a/db/masterdata/011_create_collections_data.sql
+++ b/db/masterdata/011_create_collections_data.sql
@@ -4,12 +4,12 @@
 
 INSERT INTO `collections_roles` (`id`, `name`, `oai_name`, `position`, `visible`, `visible_browsing_start`, `display_browsing`, `visible_frontdoor`, `display_frontdoor`, `visible_oai`) VALUES
 (1,'institutes','institutes',1,1,1,'Name',1,'Name',1),
-(2,'ddc','ddc',2,1,1,'Number, Name',1,'Number, Name',1),
-(3,'ccs','ccs',3,1,1,'Number, Name',1,'Number, Name',1),
-(4,'pacs','pacs',4,1,1,'Number, Name',1,'Number, Name',1),
-(5,'jel','jel',5,1,1,'Number, Name',1,'Number, Name',1),
-(6,'msc','msc',6,1,1,'Number, Name',1,'Number, Name',1),
-(7,'bk','bk',7,1,1,'Number, Name',1,'Number, Name',1);
+(2,'ddc','ddc',2,1,1,'Number,Name',1,'Number,Name',1),
+(3,'ccs','ccs',3,1,1,'Number,Name',1,'Number,Name',1),
+(4,'pacs','pacs',4,1,1,'Number,Name',1,'Number,Name',1),
+(5,'jel','jel',5,1,1,'Number,Name',1,'Number,Name',1),
+(6,'msc','msc',6,1,1,'Number,Name',1,'Number,Name',1),
+(7,'bk','bk',7,1,1,'Number,Name',1,'Number,Name',1);
 
 --
 -- Dumping data for table `collections`

--- a/tests/sql/015_create_collections.sql
+++ b/tests/sql/015_create_collections.sql
@@ -1,8 +1,8 @@
 INSERT INTO `collections_roles` (`id`, `name`, `oai_name`, `position`, `visible`, `visible_browsing_start`, `display_browsing`, `visible_frontdoor`, `display_frontdoor`, `visible_oai`) VALUES
 (10, 'series', 'series', 10, 1, 1, 'Name', 1, 'Name', 1),
 (9, 'collections', 'collections', 9, 1, 1, 'Name', 1, 'Name', 1),
-(11, 'reports', 'reports', 11, 1, 1, 'Number, Name', 1, 'Number, Name', 1),
-(15, 'projects', 'projects', 12, 1, 1, 'Number, Name', 1, 'Number, Name', 1),
+(11, 'reports', 'reports', 11, 1, 1, 'Number,Name', 1, 'Number,Name', 1),
+(15, 'projects', 'projects', 12, 1, 1, 'Number,Name', 1, 'Number,Name', 1),
 (17, 'no-root-test', 'no-root-test', 13, 0, 0, 'Name', 1, 'Name', 1),
 (18, 'frontdoor-test-1', 'frontdoor-test-1', 14, 1, 1, 'Name', 1, 'Name', 1),
 (19, 'frontdoor-test-2', 'frontdoor-test-2', 15, 1, 1, 'Name', 1, 'Name', 1),


### PR DESCRIPTION
Mit OPUS 4.5 wurde eine Änderung in der Interpretation der Werte `display_browsing` und `display_frontdoor` eingefügt. Die früher verwendete Schreibweise `NameNumber` bzw. `NumberName` wurde ersetzt durch `Name,Number` bzw. `Number,Name`. Diese Änderung wurde im Update-DB-Skript `update-4.5.sql` berücksichtigt. In die Master-Daten wurde allerdings fälschlicherweise ein Leerzeichen nach dem Komma eingefügt (`Number, Name`), was dazu führt, dass in der entsprechenden Select-Box in der Administration-View ein falscher Wert angezeigt wird. 

Durch die Entfernung des Leerzeichens wird die korrekte Funktion wiederhergestellt.