### PR TITLE
display document's attribute belongsToBibliography on frontdoor

### DIFF
--- a/modules/frontdoor/language/frontdoor.tmx
+++ b/modules/frontdoor/language/frontdoor.tmx
@@ -724,7 +724,23 @@
         </tuv>
     </tu>
 
-    
-    
+    <tu tuid="frontdoor_belongsToBibliography_0">
+        <tuv xml:lang="en">
+            <seg>no</seg>
+        </tuv>
+        <tuv xml:lang="de">
+            <seg>nein</seg>
+        </tuv>
+    </tu>
+
+   <tu tuid="frontdoor_belongsToBibliography_1">
+        <tuv xml:lang="en">
+            <seg>yes</seg>
+        </tuv>
+        <tuv xml:lang="de">
+            <seg>ja</seg>
+        </tuv>
+    </tu>
+
   </body>
 </tmx>

--- a/modules/frontdoor/views/scripts/index/index.xslt
+++ b/modules/frontdoor/views/scripts/index/index.xslt
@@ -308,6 +308,7 @@
 
             <xsl:apply-templates select="Patent" />
             <xsl:apply-templates select="Licence" />
+            <xsl:apply-templates select="@BelongsToBibliography" />
         </table>
 
     </xsl:template>

--- a/modules/frontdoor/views/scripts/index/index.xslt
+++ b/modules/frontdoor/views/scripts/index/index.xslt
@@ -308,7 +308,13 @@
 
             <xsl:apply-templates select="Patent" />
             <xsl:apply-templates select="Licence" />
-            <xsl:apply-templates select="@BelongsToBibliography" />
+
+            <!-- TODO add new config option to control whether this attribute is displayed on document's frontdoor
+                      this option is needed since we cannot decide if attribute belongsToBibliography is
+                      used in a given instance or not as there are only 2 valid attribute values -->
+            <!-- as long as this new config option is missing: uncomment the following apply-template element if
+                 you wish to display belongsToBibliography on document's frontdoor -->
+            <!--xsl:apply-templates select="@BelongsToBibliography" -->
         </table>
 
     </xsl:template>

--- a/modules/frontdoor/views/scripts/index/templates/metadata.xslt
+++ b/modules/frontdoor/views/scripts/index/templates/metadata.xslt
@@ -105,6 +105,19 @@
         </tr>
     </xsl:template>
 
+    <xsl:template match="@BelongsToBibliography">
+        <tr>
+            <th class="name">
+                <xsl:call-template name="translateFieldname" />
+            </th>
+            <td>
+                <xsl:call-template name="translateString">
+                   <xsl:with-param name="string">frontdoor_belongsToBibliography_<xsl:value-of select="." /></xsl:with-param>
+                </xsl:call-template>
+            </td>
+        </tr>
+    </xsl:template>
+
     <!-- -->
     <!-- Templates for "external fields". -->
     <!-- -->


### PR DESCRIPTION
Implementation of Feature Request OPUSVIER-3563. 

Es wäre schön, wenn diese Änderung in OPUS 4.5 einfließen könnte, so dass es in der BAM-Instanz zeitnah sichtbar wird.