### PR TITLE
OPUSVIER-3709 Stylesheet custom.css always used.

### DIFF
--- a/public/layouts/opus4/common.phtml
+++ b/public/layouts/opus4/common.phtml
@@ -57,6 +57,7 @@ $this->headLink()
     ->appendStylesheet($this->baseUrl() . '/' . $config->css->jqueryui->path, 'screen')
     ->appendStylesheet($this->layoutPath() . '/css/opus.css', 'screen,print')
     ->appendStylesheet($this->layoutPath() . '/css/admin.css', 'screen,print')
+    ->appendStylesheet($this->layoutPath() . '/css/custom.css')
     ->headLink(array(
         'rel' => 'shortcut icon',
         'type' => 'image/x-icon',
@@ -66,11 +67,6 @@ $this->headLink()
         'title' => 'OPUS 4 Search',
         'type' => 'application/opensearchdescription+xml',
         'href' => $this->serverUrl() . $this->baseUrl() . '/solrsearch/opensearch'));
-
-/*
-uncomment the following line if you want to enable your own layout changes
-$this->headLink()->appendStylesheet($this->layoutPath() . '/css/custom.css');
-*/
 
 $this->container = Zend_Registry::get('Opus_Navigation');
 

--- a/public/layouts/opus4/common.phtml
+++ b/public/layouts/opus4/common.phtml
@@ -29,9 +29,8 @@
  * @author      Thoralf Klein <thoralf.klein@zib.de>
  * @author      Sascha Szott <szott@zib.de>
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2010-2015, OPUS 4 development team
+ * @copyright   Copyright (c) 2010-2017, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
  */
 
 $config = Zend_Registry::get('Zend_Config');


### PR DESCRIPTION
OPUSVIER-3709 - This is just a in between step to avoid the need to modify common.phtml on most systems. In the long run OPUS 4 will support themes.