### PR TITLE
OPUSVIER-3592 Refactoring of frontdoor xslt functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,24 @@ anhand des Titels in der Sprache der Oberfläche, der dann angezeigt
 wird. Das kann zu einer unerwarteten Reihenfolge führen. Es ist geplant
 dieses Problem in einem kommenden Release zu beheben.
 
+### Suche
+
+### Frontdoor
+
+Die PHP Funktionen die im XSLT verwendet wurden, sind jetzt als Zend
+View Helper implementiert und haben teilweise neue Namen. Das muss bei
+Repositorien berücksichtigt werden, die ihre Frontdoor angepasst haben.
+Die Änderung erlaubt einfachere Tests und Erweiterbarkeit.
+
+Anstelle von `Frontdoor_IndexController` wird jetzt `Application_Xslt`
+verwendet. Die folgenden Funktionen haben außerdem neue Namen bekommen.
+
+    checkIfFileEmbargoHasPassed -> embargoHasPassed
+    useCustomSortOrder          -> customFileSortingEnabled
+    checkIfUserHasFileAccess    -> fileAccessAllowed
+    checkLanguageFile           -> languageImageExists
+    getStylesheet               -> frontdoorStylesheet
+
 ---
 
 ## Release 4.5 2016-12-06

--- a/library/Application/Configuration.php
+++ b/library/Application/Configuration.php
@@ -331,4 +331,14 @@ class Application_Configuration {
         self::$_instance = null;
     }
 
+    /**
+     * Returns Zend_Translate instance for application.
+     * @return Zend_Translate
+     * @throws Zend_Exception
+     */
+    public function getTranslate()
+    {
+        return Zend_Registry::get('Zend_Translate');
+    }
+
 }

--- a/library/Application/View/Helper/CustomFileSortingEnabled.php
+++ b/library/Application/View/Helper/CustomFileSortingEnabled.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+
+class Application_View_Helper_CustomFileSortingEnabled extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * Check if custom file sorting based on sort order field is enabled.
+     *
+     * @return bool false - use alphabetic order.
+     */
+    public function customFileSortingEnabled()
+    {
+        return Zend_Registry::get('Zend_Config')->frontdoor->files->customSorting == '1';
+    }
+
+}

--- a/library/Application/View/Helper/EmbargoHasPassed.php
+++ b/library/Application/View/Helper/EmbargoHasPassed.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_EmbargoHasPassed extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * Checks if a document is still in embargo.
+     *
+     * @return bool true - if embargo date has passed; false - if not
+     *
+     * TODO another document instantiation (find more efficient way)
+     */
+    public static function embargoHasPassed($doc)
+    {
+        if ( ! $doc instanceof Opus_Document)
+        {
+            $doc = new Opus_Document($doc);
+        }
+
+        return $doc->hasEmbargoPassed();
+    }
+
+}

--- a/library/Application/View/Helper/FileAccessAllowed.php
+++ b/library/Application/View/Helper/FileAccessAllowed.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_FileAccessAllowed extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * Checks if user has access to file,
+     *
+     * @param string|int $fileId
+     * @return boolean
+     */
+    public function fileAccessAllowed($fileId = null)
+    {
+        if (is_null($fileId))
+        {
+            return false;
+        }
+
+        $realm = Opus_Security_Realm::getInstance();
+        return $realm->checkFile($fileId);
+    }
+
+}

--- a/library/Application/View/Helper/FormatDate.php
+++ b/library/Application/View/Helper/FormatDate.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_Xslt
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2008-2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_FormatDate extends Zend_View_Helper_Abstract
+{
+
+    public function formatDate($day, $month, $year) {
+        $date = new DateTime();
+        $date->setDate($year, $month, $day);
+        $session = new Zend_Session_Namespace();
+
+        // TODO aktuell werden nur zwei Sprachen unterstützt
+        $formatPattern = ($session->language == 'de') ? 'd.m.Y' : 'Y/m/d';
+
+        return date_format($date, $formatPattern);
+    }
+
+}

--- a/library/Application/View/Helper/FrontdoorStylesheet.php
+++ b/library/Application/View/Helper/FrontdoorStylesheet.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+/**
+ * Class Application_View_Helper_FrontdoorStylesheet
+ *
+ * TODO frontdoor supports multiple formats - what is special here?
+ */
+class Application_View_Helper_FrontdoorStylesheet extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * Returns stylesheet for frontdoor export if configured and user has access to export module.
+     * @return string
+     * @throws Zend_Exception
+     */
+    public function frontdoorStylesheet()
+    {
+        $config = Zend_Registry::get('Zend_Config');
+        if (isset($config->export->stylesheet->frontdoor) && Opus_Security_Realm::getInstance()->checkModule('export'))
+        {
+            return $config->export->stylesheet->frontdoor;
+        }
+        return '';
+    }
+
+}

--- a/library/Application/View/Helper/IsDisplayField.php
+++ b/library/Application/View/Helper/IsDisplayField.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_Xslt
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+class Application_View_Helper_IsDisplayField extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * Check if a field should be displayed in the frontdoor.
+     * @param string $name Name of field
+     * @return bool
+     */
+    public function isDisplayField($name) {
+        $config = Application_Configuration::getInstance()->getConfig();
+
+        if (is_null($config)) {
+            return false;
+        }
+
+        if (isset($config->frontdoor->metadata->$name)) {
+            return $config->frontdoor->metadata->$name == 1;
+        }
+        else {
+            return false;
+        }
+    }
+
+}

--- a/library/Application/View/Helper/LanguageImageExists.php
+++ b/library/Application/View/Helper/LanguageImageExists.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_LanguageImageExists extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * Checks existence of language image for services.xslt
+     * @param $language
+     * @return bool
+     */
+    public function languageImageExists($language)
+    {
+        return file_exists(APPLICATION_PATH . '/public/img/lang/' . $language . '.png');
+    }
+
+}

--- a/library/Application/View/Helper/TranslateWithDefault.php
+++ b/library/Application/View/Helper/TranslateWithDefault.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+/**
+ * View helper that translates key if translation is found or returns provided default value.
+ */
+class Application_View_Helper_TranslateWithDefault extends Zend_View_Helper_Abstract
+{
+
+    public function translateWithDefault($messageId, $default = '')
+    {
+        $translator = Application_Configuration::getInstance()->getTranslate();
+
+        if ($translator->isTranslated($messageId))
+        {
+            return $translator->translate($messageId);
+        }
+
+        return $default;
+    }
+
+}

--- a/library/Application/Xslt.php
+++ b/library/Application/Xslt.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+/**
+ * Provides access to view helper using static functions in XSLT.
+ */
+class Application_Xslt
+{
+
+    /**
+     * @var Application_Xslt
+     */
+    private static $_singleton = null;
+
+    /**
+     * Prevent external construction of this class.
+     */
+    private function __construct() {
+    }
+
+    /**
+     * Returns singleton instance of this class.
+     * @return Application_Xslt
+     */
+    public static function getInstance()
+    {
+        if (is_null(self::$_singleton))
+        {
+            self::$_singleton = new Application_Xslt();
+        }
+
+        return self::$_singleton;
+    }
+
+    /**
+     * Catches calls to static functions and redirects them to view helpers.
+     * @param $method Name of function
+     * @param $arguments Arguments of function
+     * @return mixed Result of the function
+     */
+    public static function __callStatic($method, $arguments)
+    {
+        $helper = self::getInstance()->findHelper($method);
+
+        if (!is_null($helper)) {
+            return call_user_func_array(array($helper, $method), $arguments);
+        }
+
+        return parent::__call($method, $arguments);
+    }
+
+    /**
+     * Finds helpers in the set of available view helpers.
+     * @param $method Name of helper
+     * @return mixed Zend_View_Helper
+     * @throws Zend_Exception
+     */
+    public function findHelper($method) {
+        $helper = Zend_Registry::get('Opus_View')->getHelper($method);
+
+        return $helper;
+    }
+
+    /**
+     * Returns the names of the functions that are supported.
+     * @param $processor XSLTProcessor
+     * @return array Names of supported functions
+     */
+    public static function registerViewHelper($processor, $allowedFunctions)
+    {
+        $functions = array_map(
+            function($value)
+            {
+                return 'Application_Xslt::' . $value;
+            },
+            $allowedFunctions
+        );
+
+        $processor->registerPHPFunctions($functions);
+    }
+
+}

--- a/modules/frontdoor/controllers/IndexController.php
+++ b/modules/frontdoor/controllers/IndexController.php
@@ -29,26 +29,17 @@
  * @package     Module_Frontdoor
  * @author      Felix Ostrowski <ostrowski@hbz-nrw.de>
  * @author      Michael Lang <lang@zib.de>
+ * @author      Jens Schwidder <schwidder@zib.de>
  * @copyright   Copyright (c) 2014, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
- *
- * TODO move XSLT functions into model class (makes unit tests easier)
  */
 class Frontdoor_IndexController extends Application_Controller_Action {
 
+    /**
+     * TODO should be defined in central model classes
+     */
     const SERVER_STATE_DELETED = 'deleted';
     const SERVER_STATE_UNPUBLISHED = 'unpublished';
-    // functions
-    const TRANSLATE_FUNCTION = 'Frontdoor_IndexController::translate';
-    const TRANSLATE_DEFAULT_FUNCTION = 'Frontdoor_IndexController::translateWithDefault';
-    const FILE_ACCESS_FUNCTION = 'Frontdoor_IndexController::checkIfUserHasFileAccess';
-    const FORMAT_DATE_FUNCTION = 'Frontdoor_IndexController::formatDate';
-    const EMBARGO_ACCESS_FUNCTION = 'Frontdoor_IndexController::checkIfFileEmbargoHasPassed';
-    const SORT_ORDER_FUNCTION = 'Frontdoor_IndexController::useCustomSortOrder';
-    const CHECK_LANGUAGE_FILE_FUNCTION = 'Frontdoor_IndexController::checkLanguageFile';
-    const GET_STYLESHEET_FUNCTION = 'Frontdoor_IndexController::getStylesheet';
-    const IS_DISPLAY_FIELD_FUNCTION = 'Frontdoor_IndexController::isDisplayField';
 
     /**
      * Displays the metadata of a document.
@@ -152,15 +143,17 @@ class Frontdoor_IndexController extends Application_Controller_Action {
         $xslt = $docBuilder->buildDomDocument($this->view->getScriptPath('index') . DIRECTORY_SEPARATOR . 'index');
 
         $proc = new XSLTProcessor;
-        $proc->registerPHPFunctions(self::TRANSLATE_FUNCTION);
-        $proc->registerPHPFunctions(self::TRANSLATE_DEFAULT_FUNCTION);
-        $proc->registerPHPFunctions(self::FILE_ACCESS_FUNCTION);
-        $proc->registerPHPFunctions(self::FORMAT_DATE_FUNCTION);
-        $proc->registerPHPFunctions(self::EMBARGO_ACCESS_FUNCTION);
-        $proc->registerPHPFunctions(self::SORT_ORDER_FUNCTION);
-        $proc->registerPHPFunctions(self::CHECK_LANGUAGE_FILE_FUNCTION);
-        $proc->registerPHPFunctions(self::GET_STYLESHEET_FUNCTION);
-        $proc->registerPHPFunctions(self::IS_DISPLAY_FIELD_FUNCTION);
+        Application_Xslt::registerViewHelper($proc, array(
+            'translate',
+            'translateWithDefault',
+            'formatDate',
+            'isDisplayField',
+            'fileAccessAllowed',
+            'embargoHasPassed',
+            'customFileSortingEnabled',
+            'languageImageExists',
+            'frontdoorStylesheet'
+        ));
         $proc->registerPHPFunctions('urlencode');
         $proc->importStyleSheet($xslt);
 
@@ -225,54 +218,9 @@ class Frontdoor_IndexController extends Application_Controller_Action {
         return count($authors->getContactableAuthors()) > 0;
     }
 
-    /**
-     * Static function to be called from XSLT script to check file permission.
-     *
-     * @param string|int $fileId
-     * @return boolean
-     */
-    public static function checkIfUserHasFileAccess($fileId = null) {
-        if (is_null($fileId)) {
-            return false;
-        }
 
-        $realm = Opus_Security_Realm::getInstance();
-        return $realm->checkFile($fileId);
-    }
 
-    /**
-     * Invokes Opus_Document::hasEmbargoPassed(); compares EmbargoDate with parameter or system time.
-     *
-     * @param Opus_Date $now
-     * @return bool true - if embargo date has passed; false - if not
-     *
-     * TODO another document instantiation (find more efficient way)
-     */
-    public static function checkIfFileEmbargoHasPassed($docId) {
-        $doc = new Opus_Document($docId);
-        return $doc->hasEmbargoPassed();
-    }
 
-    /**
-     * Checks existence of language sign for services.xslt
-     * @param $filename
-     * @return bool
-     */
-    public static function checkLanguageFile($language) {
-        if (file_exists(APPLICATION_PATH . '/public/img/lang/' . $language . '.png')) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Use custom sorting according to the sort order field.
-     * if (false) -> use alphabetic order.
-     */
-    public static function useCustomSortOrder() {
-        return Zend_Registry::get('Zend_Config')->frontdoor->files->customSorting == '1';
-    }
 
     /**
      *
@@ -388,11 +336,11 @@ class Frontdoor_IndexController extends Application_Controller_Action {
             'DC.Identifier', $this->view->fullUrl() . '/frontdoor/index/index/docId/' . $document->getId()
         );
 
-        if (self::checkIfFileEmbargoHasPassed($document->getId())) {
+        if (Application_Xslt::embargoHasPassed($document)) {
             foreach ($document->getFile() AS $file) {
                 if (!$file->exists()
                         or ($file->getVisibleInFrontdoor() !== '1')
-                        or !self::checkIfUserHasFileAccess($file->getId())) {
+                        or !Application_Xslt::fileAccessAllowed($file->getId())) {
                     continue;
                 }
                 $metas[] = array('DC.Identifier', "$baseUrlFiles/" . $document->getId() . "/" . $file->getPathName());
@@ -449,72 +397,6 @@ class Frontdoor_IndexController extends Application_Controller_Action {
     public function mapopus3Action() {
         $docId = $this->getRequest()->getParam('oldId');
         $this->_redirectToAndExit('id', '', 'index', 'rewrite', array('type' => 'opus3-id', 'value' => $docId));
-    }
-
-    /**
-     * Gateway function to Zend's translation facilities.
-     *
-     * @param  string  $key The key of the string to translate.
-     * @return string  The translated string.
-     */
-    static public function translate($key) {
-        $registry = Zend_Registry::getInstance();
-        $translate = $registry->get('Zend_Translate');
-        return $translate->_($key);
-    }
-
-    /**
-     * Check if a field should be displayed in the frontdoor.
-     * @param string $name Name of field
-     * @return bool
-     */
-    static public function isDisplayField($name) {
-        $config = Zend_Registry::get('Zend_Config');
-
-        if (is_null($config)) {
-            return false;
-        }
-
-        if (isset($config->frontdoor->metadata->$name)) {
-            return $config->frontdoor->metadata->$name == 1;
-        }
-        else {
-            return false;
-        }
-    }
-
-    /**
-     * Gateway function to Zend's translation facilities.  Falls back to default
-     * if no translation exists.
-     *
-     * @param  string  $key     The key of the string to translate.
-     * @param  string  $default The default value of no translation exists
-     * @return string  The translated string *or* the default value
-     */
-    static public function translateWithDefault($key, $default = '') {
-        $translate = Zend_Registry::get('Zend_Translate');
-        /* @var $translate Zend_Translate_Adapter */
-        if ($translate->isTranslated($key)) {
-            return $translate->_($key);
-        }
-        return $default;
-    }
-
-    static public function formatDate($day, $month, $year) {
-        $date = new DateTime();
-        $date->setDate($year, $month, $day);
-        $session = new Zend_Session_Namespace();
-        // TODO aktuell werden nur zwei Sprachen unterstützt
-        $formatPattern = ($session->language == 'de') ? 'd.m.Y' : 'Y/m/d';
-        return date_format($date, $formatPattern);
-    }
-
-    public static function getStylesheet() {
-        $config = Zend_Registry::get('Zend_Config');
-        if (isset($config->export->stylesheet->frontdoor) && Opus_Security_Realm::getInstance()->checkModule('export')) {
-            return $config->export->stylesheet->frontdoor;
-        }
-        return '';
     }
 
 }

--- a/modules/frontdoor/views/scripts/index/index.xslt
+++ b/modules/frontdoor/views/scripts/index/index.xslt
@@ -96,7 +96,7 @@
       <div id="services" class="services-menu">
          <xsl:if test="normalize-space(File/@PathName) and File[@VisibleInFrontdoor='1']">
              <xsl:choose>
-                <xsl:when test="php:functionString('Frontdoor_IndexController::checkIfFileEmbargoHasPassed', @Id)">
+                <xsl:when test="php:functionString('Application_Xslt::embargoHasPassed', @Id)">
                     <div id="download-fulltext" class="services">
                        <h3>
                           <xsl:call-template name="translateString">
@@ -105,7 +105,7 @@
                        </h3>
                        <ul>
                            <xsl:choose>
-                               <xsl:when test="php:functionString('Frontdoor_IndexController::useCustomSortOrder', @Id)">
+                               <xsl:when test="php:functionString('Application_Xslt::customFileSortingEnabled', @Id)">
                                   <xsl:apply-templates select="File[@VisibleInFrontdoor='1']">
                                      <xsl:sort select="@SortOrder" data-type="number" />
                                   </xsl:apply-templates>
@@ -309,7 +309,7 @@
             <xsl:apply-templates select="Patent" />
             <xsl:apply-templates select="Licence" />
 
-            <xsl:if test="php:functionString('Frontdoor_IndexController::isDisplayField', 'BelongsToBibliography')">
+            <xsl:if test="php:functionString('Application_Xslt::isDisplayField', 'BelongsToBibliography')">
                 <xsl:apply-templates select="@BelongsToBibliography" />
             </xsl:if>
         </table>

--- a/modules/frontdoor/views/scripts/index/templates/functions.xslt
+++ b/modules/frontdoor/views/scripts/index/templates/functions.xslt
@@ -45,7 +45,7 @@
 
     <!-- Named template to translate a field's name. Needs no parameter. -->
     <xsl:template name="translateFieldname">
-        <xsl:value-of select="php:functionString('Frontdoor_IndexController::translate', name())" />
+        <xsl:value-of select="php:functionString('Application_Xslt::translate', name())" />
         <xsl:if test="normalize-space(@Language)">
             <!-- translation of language abbreviations  -->
             <xsl:text> (</xsl:text>
@@ -60,13 +60,13 @@
     <!-- Named template to translate an arbitrary string. Needs the translation key as a parameter. -->
     <xsl:template name="translateString">
         <xsl:param name="string" />
-        <xsl:value-of select="php:functionString('Frontdoor_IndexController::translate', $string)" />
+        <xsl:value-of select="php:functionString('Application_Xslt::translate', $string)" />
     </xsl:template>
 
     <xsl:template name="translateStringWithDefault">
         <xsl:param name="string" />
         <xsl:param name="default" />
-        <xsl:value-of select="php:functionString('Frontdoor_IndexController::translateWithDefault', $string, $default)" />
+        <xsl:value-of select="php:functionString('Application_Xslt::translateWithDefault', $string, $default)" />
     </xsl:template>
 
     <xsl:template name="replaceCharsInString">
@@ -92,6 +92,6 @@
         <xsl:param name="day"/>
         <xsl:param name="month"/>
         <xsl:param name="year"/>
-        <xsl:value-of select="php:functionString('Frontdoor_IndexController::formatDate', $day, $month, $year)" />
+        <xsl:value-of select="php:functionString('Application_Xslt::formatDate', $day, $month, $year)" />
     </xsl:template>
 </xsl:stylesheet>

--- a/modules/frontdoor/views/scripts/index/templates/services.xslt
+++ b/modules/frontdoor/views/scripts/index/templates/services.xslt
@@ -63,7 +63,7 @@
 
           <xsl:variable name="flagIcon">
               <xsl:choose>
-                  <xsl:when test="php:functionString('Frontdoor_IndexController::checkLanguageFile', @Language)">
+                  <xsl:when test="php:functionString('Application_Xslt::languageImageExists', @Language)">
                       <img width="16" height="11">
                           <xsl:attribute name="src">
                               <xsl:value-of select="$baseUrl"/>
@@ -115,7 +115,7 @@
          </xsl:variable>
 
          <xsl:choose>
-            <xsl:when test="php:functionString('Frontdoor_IndexController::checkIfUserHasFileAccess', @Id)">
+            <xsl:when test="php:functionString('Application_Xslt::fileAccessAllowed', @Id)">
                <div class="accessible-file">
                   <xsl:attribute name="title">
                      <xsl:call-template name="translateString">
@@ -327,7 +327,7 @@
 
       <!--Xml-Export-->
       <xsl:choose>
-          <xsl:when test="php:functionString('Frontdoor_IndexController::getStylesheet') != '' ">
+          <xsl:when test="php:functionString('Application_Xslt::frontdoorStylesheet') != '' ">
               <li>
                   <xsl:element name="a">
                       <!--TODO: Use Zend Url-Helper to build href attribute-->
@@ -336,7 +336,7 @@
                           <xsl:text>/frontdoor/index/index/docId/</xsl:text>
                           <xsl:value-of select="@Id" />
                           <xsl:text>/export/xml/stylesheet/</xsl:text>
-                          <xsl:value-of select="php:functionString('Frontdoor_IndexController::getStylesheet')" />
+                          <xsl:value-of select="php:functionString('Application_Xslt::frontdoorStylesheet')" />
                       </xsl:attribute>
                       <xsl:attribute name="title">
                           <xsl:call-template name="translateString">

--- a/tests/library/Application/View/Helper/CustomFileSortingEnabledTest.php
+++ b/tests/library/Application/View/Helper/CustomFileSortingEnabledTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_CustomFileSortingEnabledTest extends ControllerTestCase
+{
+
+    public function testCustomFileSortingEnabled()
+    {
+        $helper = new Application_View_Helper_CustomFileSortingEnabled();
+
+        $this->assertTrue($helper->customFileSortingEnabled());
+
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(array(
+            'frontdoor' => array('files' => array('customSorting' => '0'))
+        )));
+
+        $this->assertFalse($helper->customFileSortingEnabled());
+    }
+
+}

--- a/tests/library/Application/View/Helper/EmbargoHasPassedTest.php
+++ b/tests/library/Application/View/Helper/EmbargoHasPassedTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_EmbargoHasPassedTest extends ControllerTestCase
+{
+
+    public function testEmbargoHasPassedForDocumentObject()
+    {
+        $helper = new Application_View_Helper_EmbargoHasPassed();
+
+        $document = $this->createTestDocument();
+        $document->store();
+
+        $this->assertTrue($helper->embargoHasPassed($document));
+
+        $document->setEmbargoDate(new Opus_Date(new DateTime('tomorrow')));
+
+        $this->assertFalse($helper->embargoHasPassed($document));
+    }
+
+    public function testEmbargoHasPassed() {
+        $helper = new Application_View_Helper_EmbargoHasPassed();
+
+        $document = $this->createTestDocument();
+        $docId = $document->store();
+
+        $this->assertTrue($helper->embargoHasPassed($docId));
+
+        $document->setEmbargoDate(new Opus_Date(new DateTime('tomorrow')));
+        $document->store();
+
+        $this->assertFalse($helper->embargoHasPassed($docId));
+    }
+
+}

--- a/tests/library/Application/View/Helper/FileAccessAllowedTest.php
+++ b/tests/library/Application/View/Helper/FileAccessAllowedTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_FileAccessAllowedTest extends ControllerTestCase
+{
+
+    public function testFileAccessAllowed()
+    {
+        $this->enableSecurity();
+
+        $helper = new Application_View_Helper_FileAccessAllowed();
+
+        $this->assertFalse($helper->fileAccessAllowed(null));
+
+        $file = $this->createTestFile('accesstest.txt');
+
+        $this->assertFalse($helper->fileAccessAllowed($file));
+
+        $this->loginUser('admin', 'adminadmin');
+
+        $this->assertTrue($helper->fileAccessAllowed($file));
+    }
+
+
+}

--- a/tests/library/Application/View/Helper/FormatDateTest.php
+++ b/tests/library/Application/View/Helper/FormatDateTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_FormatDateTest extends ControllerTestCase
+{
+
+    public function testFormatDate()
+    {
+        $helper = new Application_View_Helper_FormatDate();
+
+        $this->useEnglish(); // rendering depends on language set in session
+
+        $this->assertEquals('2017/10/21', $helper->formatDate('21', '10', '2017'));
+        $this->assertEquals('2017/10/21', $helper->formatDate(21, 10, 2017));
+
+        $this->useGerman();
+
+        $this->assertEquals('21.10.2017', $helper->formatDate('21', '10', '2017'));
+        $this->assertEquals('21.10.2017', $helper->formatDate(21, 10, 2017));
+    }
+
+}

--- a/tests/library/Application/View/Helper/FrontdoorStylesheetTest.php
+++ b/tests/library/Application/View/Helper/FrontdoorStylesheetTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_FrontdoorStylesheetTest extends ControllerTestCase
+{
+
+    public function testFrontdoorStylesheet()
+    {
+        $helper = new Application_View_Helper_FrontdoorStylesheet();
+
+        $this->assertEquals('', $helper->frontdoorStylesheet());
+
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(array(
+            'export' => array('stylesheet' => array('frontdoor' => 'test.xslt'))
+        )));
+
+        $this->assertEquals('test.xslt', $helper->frontdoorStylesheet());
+    }
+
+    public function testFrontdoorStylesheetAccess()
+    {
+        $this->enableSecurity();
+
+        $helper = new Application_View_Helper_FrontdoorStylesheet();
+
+        $this->assertEquals('', $helper->frontdoorStylesheet());
+
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(array(
+            'export' => array('stylesheet' => array('frontdoor' => 'test.xslt'))
+        )));
+
+        $this->assertFalse(Opus_Security_Realm::getInstance()->checkModule('export'));
+
+        $this->assertEquals('', $helper->frontdoorStylesheet());
+
+        $this->loginUser('admin', 'adminadmin');
+
+        $this->assertTrue(Opus_Security_Realm::getInstance()->checkModule('export'));
+
+        $this->assertEquals('test.xslt', $helper->frontdoorStylesheet());
+    }
+
+}

--- a/tests/library/Application/View/Helper/IsDisplayFieldTest.php
+++ b/tests/library/Application/View/Helper/IsDisplayFieldTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_IsDisplayFieldTest extends ControllerTestCase
+{
+
+    public function testIsDisplayField()
+    {
+        $helper = new Application_View_Helper_IsDisplayField();
+
+        $this->assertFalse($helper->isDisplayField('BelongsToBibliography'));
+
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(array(
+            'frontdoor' => array('metadata' => array('BelongsToBibliography' => '1'))
+        )));
+
+        $this->assertTrue($helper->isDisplayField('BelongsToBibliography'));
+    }
+
+    public function testIsDisplayFieldForUnknownField()
+    {
+        $helper = new Application_View_Helper_IsDisplayField();
+
+        $this->assertFalse($helper->isDisplayField('unknown'));
+    }
+
+}

--- a/tests/library/Application/View/Helper/LanguageImageExistsTest.php
+++ b/tests/library/Application/View/Helper/LanguageImageExistsTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_LanguageImageExistsTest extends ControllerTestCase
+{
+
+    public function testLanguageImageExists()
+    {
+        $helper = new Application_View_Helper_LanguageImageExists();
+
+        $this->assertTrue($helper->languageImageExists('deu'));
+        $this->assertFalse($helper->languageImageExists('de'));
+        $this->assertFalse($helper->languageImageExists('ger'));
+
+        $this->assertTrue($helper->languageImageExists('eng'));
+        $this->assertFalse($helper->languageImageExists('en'));
+
+        $this->assertFalse($helper->languageImageExists('abc'));
+    }
+
+}

--- a/tests/library/Application/View/Helper/TranslateWithDefaultTest.php
+++ b/tests/library/Application/View/Helper/TranslateWithDefaultTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     View_Helper
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_View_Helper_TranslateWithDefaultTest extends ControllerTestCase
+{
+
+    public function testTranslateWithDefault()
+    {
+        $helper = new Application_View_Helper_TranslateWithDefault();
+
+        $this->useEnglish();
+
+        $this->assertEquals('Default', $helper->translateWithDefault('notakey', 'Default'));
+        $this->assertEquals('', $helper->translateWithDefault('notakey'));
+        $this->assertNotNull('', $helper->translateWithDefault('notakey', null));
+        $this->assertEquals('', $helper->translateWithDefault('notakey', null));
+
+        $this->assertEquals('Yes', $helper->translateWithDefault('answer_yes', 'Ja'));
+    }
+
+}

--- a/tests/library/Application/XsltTest.php
+++ b/tests/library/Application/XsltTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application Unit Test
+ * @package     Application
+ * @author      Jens Schwidder <schwidder@zib.de>
+ * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+class Application_XsltTest extends ControllerTestCase
+{
+
+    public function testGetInstance()
+    {
+        $xslt = Application_Xslt::getInstance();
+
+        $this->assertNotNull($xslt);
+        $this->assertInstanceOf('Application_Xslt', $xslt);
+
+        $this->assertSame($xslt, Application_Xslt::getInstance());
+    }
+
+    public function testRegisterViewHelper() {
+        $processor = new XSLTProcessor();
+
+        Application_Xslt::registerViewHelper($processor, array(
+            'translate', 'formatDate'
+        ));
+
+        $this->markTestIncomplete('no assertions');
+    }
+
+    public function testFindHelper()
+    {
+        $xslt = Application_Xslt::getInstance();
+
+        $helper = $xslt->findHelper('translate');
+
+        $this->assertNotNull($helper);
+        $this->assertInstanceOf('Application_View_Helper_Translate', $helper);
+    }
+
+    public function testCallStatic()
+    {
+        $this->assertEquals('Yes', Application_Xslt::translate('answer_yes'));
+    }
+
+}


### PR DESCRIPTION
The static functions of the frontdoor controller class used by the xslt processing have been refactored as view helpers that can now be registered with the XSLT processor.