### PR TITLE
Ausgabe der ID des Dokuments aus User Session in Fehler-E-Mail

### DIFF
--- a/modules/default/controllers/ErrorController.php
+++ b/modules/default/controllers/ErrorController.php
@@ -182,6 +182,13 @@ class ErrorController extends Application_Controller_Action {
             $body .= "   message: " . $view->message . "\n";
         }
         $body .= "\n";
+        
+        $session = new Zend_Session_Namespace('Publish');
+        if (isset($session->documentId)) {
+            $body .= "User Session (Namespace Publish):\n";
+            $body .= "   Document ID: " . $session->documentId . "\n";
+        }
+        $body .= "\n";
 
         $body .= "Request:\n";
         $serverKeys = array('HTTP_USER_AGENT', 'SCRIPT_URI', 'HTTP_REFERER', 'REMOTE_ADDR');


### PR DESCRIPTION
Im Falle eines Fehler im letzten Schritt des Publikationsformulars (/publish/deposit/deposit) kann aus der Fehler-E-Mail leider nicht abgelesen werden, warum es genau zu dem Fehler kam. Es werden zwar alle POST-Parameter des HTTP Requests ausgegeben, allerdings ist das in diesem Fall nicht zielführend, weil die Informationen zum gerade abgeschickten Dokument ausschließlich in der User Session gehalten werden (und zwar im Namespace Publish). Im Fall des Deposit gibt es nur einen POST-Parameter (Name "send" mit dem Wert "Dokument abspeichern"), der sich durch den Submit-Button ergibt. Eine Ableitung der zuvor eingegebenen Metadaten ist somit unmöglich.

Der Patch erweitert die Fehler-E-Mail um die ID des Dokuments, das gerade durch den Benutzer eingegeben wurde. Die ID des Dokuments wird natürlich nur ausgegeben, wenn es diese überhaupt in der User Session gibt. Damit erscheint die Dokument-ID nur bei Fehler im Kontext des Publish-Formulars.