### PR TITLE
Aenderungen zu DINI-Zertifikat: Maschinenlesbare Angaben zur Rechtesi…

### DIFF
--- a/modules/frontdoor/controllers/IndexController.php
+++ b/modules/frontdoor/controllers/IndexController.php
@@ -336,6 +336,12 @@ class Frontdoor_IndexController extends Application_Controller_Action {
                 $metas[] = array("DC.Date", $yearPublished);
             }
         }
+        $licences = $document->getLicence();
+        foreach ($licences as $docLicence) {
+                   $metas[] = array('DC.rights', $docLicence->getModel()->getLinkLicence() );
+
+            }
+
 
         return $metas;
     }

--- a/modules/oai/views/scripts/index/prefixes/oai_dc.xslt
+++ b/modules/oai/views/scripts/index/prefixes/oai_dc.xslt
@@ -326,7 +326,7 @@
 
     <xsl:template match="Licence" mode="oai_dc">
         <dc:rights>
-            <xsl:value-of select="@NameLong" />
+            <xsl:value-of select="@LinkLicence" />
         </dc:rights>
     </xsl:template>
 


### PR DESCRIPTION
OPUSVIER-3485
DINI Zertifikat: Maschinenlesbare Angaben zur Rechtesituation in den Metadaten der veröffentlichten Dokumente (Frontdoor und OAI)