### PR TITLE
OPUSVIER-3580 Option Schriftenreihen immer alphabetisch zu sortieren

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -250,6 +250,8 @@ browsing.disableEmptyCollections = 1
 browsing.series.sortByTitle = 0
 
 ; SERIES SETTINGS
+; If series.sortByTitle is enabled (1) the sort_order will be ignored and series
+; will always be sorted by title.
 series.sortByTitle = 0
 
 ; URN Settings

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -249,6 +249,9 @@ plugins.export.publist.stylesheetDirectory = 'publist'
 browsing.disableEmptyCollections = 1
 browsing.series.sortByTitle = 0
 
+; SERIES SETTINGS
+series.sortByTitle = 0
+
 ; URN Settings
 urn.resolverUrl =  https://nbn-resolving.org/
 


### PR DESCRIPTION
Die angegebene **SortOrder** wird dann ignoriert.