### PR TITLE
Opusvier 3926

### DIFF
--- a/tests/library/Application/Form/Decorator/FileHashTest.php
+++ b/tests/library/Application/Form/Decorator/FileHashTest.php
@@ -27,7 +27,8 @@
  * @category    Application Unit Test
  * @package     Application_Form_Decorator
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2008-2013, OPUS 4 development team
+ * @author      Maximilian Salomon <salomon@zib.de>
+ * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  * @version     $Id$
  */

--- a/tests/library/Application/Form/Decorator/FileHashTest.php
+++ b/tests/library/Application/Form/Decorator/FileHashTest.php
@@ -101,6 +101,7 @@ class Application_Form_Decorator_FileHashTest extends ControllerTestCase {
     }
 
     public function testRenderWithMissingFile() {
+        $this->useEnglish();
         $element = new Application_Form_Element_FileHash('name');
 
         $file = new Opus_File(123);
@@ -127,6 +128,7 @@ class Application_Form_Decorator_FileHashTest extends ControllerTestCase {
     }
 
     public function testRenderWithFileTooBig() {
+        $this->useEnglish();
         $config = Zend_Registry::get('Zend_Config');
         $config->merge(new Zend_Config(array('checksum' => array('maxVerificationSize' => '0'))));
 

--- a/tests/library/Application/XsltTest.php
+++ b/tests/library/Application/XsltTest.php
@@ -66,6 +66,7 @@ class Application_XsltTest extends ControllerTestCase
 
     public function testCallStatic()
     {
+        $this->useEnglish();
         $this->assertEquals('Yes', Application_Xslt::translate('answer_yes'));
     }
 

--- a/tests/library/Application/XsltTest.php
+++ b/tests/library/Application/XsltTest.php
@@ -27,7 +27,8 @@
  * @category    Application Unit Test
  * @package     Application
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @author      Maximilian Salomon <salomon@zib.de>
+ * @copyright   Copyright (c) 2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 

--- a/tests/modules/AppModeTest.php
+++ b/tests/modules/AppModeTest.php
@@ -45,6 +45,7 @@ class AppModeTest extends ControllerTestCase {
 
     public function testTestingMode() {
         parent::setUpWithEnv('testing');
+        $this->useEnglish();
         $this->dispatch('/home');
         $this->assertContains('NON PRODUCTION ENVIRONMENT (testing)', $this->getResponse()->getBody());
     }

--- a/tests/modules/AppModeTest.php
+++ b/tests/modules/AppModeTest.php
@@ -26,7 +26,8 @@
  *
  * @category    Application Unit Test
  * @author      Sascha Szott <szott@zib.de>
- * @copyright   Copyright (c) 2008-2013, OPUS 4 development team
+ * @author      Maximilian Salomon <salomon@zib.de>
+ * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  * @version     $Id$
  */

--- a/tests/modules/admin/controllers/DocumentControllerTest.php
+++ b/tests/modules/admin/controllers/DocumentControllerTest.php
@@ -27,6 +27,7 @@
  * @category    Tests
  * @author      Jens Schwidder <schwidder@zib.de>
  * @author      Michael Lang <lang@zib.de>
+ * @author      Maximilian Salomon <salomon@zib.de>
  * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */

--- a/tests/modules/admin/controllers/DocumentControllerTest.php
+++ b/tests/modules/admin/controllers/DocumentControllerTest.php
@@ -266,6 +266,7 @@ class Admin_DocumentControllerTest extends ControllerTestCase {
     }
 
     public function testEditActionValidXHTML() {
+        $this->useEnglish();
         $this->dispatch('/admin/document/edit/id/146');
         $this->assertResponseCode(200);
         $this->assertModule('admin');

--- a/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
+++ b/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
@@ -26,6 +26,7 @@
  *
  * @category    Tests
  * @author      Gunar Maiwald <maiwald@zib.de>
+ * @author      Maximilian Salomon <salomon@zib.de>
  * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */

--- a/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
+++ b/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
@@ -123,6 +123,7 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase {
     }
 
     public function testNewActionSaveForExistingEnrichment() {
+        $this->useEnglish();
         $this->createsModels = true;
 
         $post = array(

--- a/tests/modules/admin/controllers/ReportControllerTest.php
+++ b/tests/modules/admin/controllers/ReportControllerTest.php
@@ -83,6 +83,7 @@ class Admin_ReportControllerTest extends ControllerTestCase {
     }
 
     public function testDoiActionWithEmptyResult() {
+        $this->useEnglish();
         $this->dispatch('/admin/report/doi');
         $this->assertResponseCode(200);
         $this->assertModule('admin');

--- a/tests/modules/admin/controllers/ReportControllerTest.php
+++ b/tests/modules/admin/controllers/ReportControllerTest.php
@@ -26,6 +26,7 @@
  *
  * @category    Unit Tests
  * @author      Sascha Szott <szott@zib.de>
+ * @author      Maximilian Salomon <salomon@zib.de>
  * @copyright   Copyright (c) 2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */

--- a/tests/modules/admin/controllers/StatisticControllerTest.php
+++ b/tests/modules/admin/controllers/StatisticControllerTest.php
@@ -26,6 +26,7 @@
  *
  * @category    Tests
  * @author      Jens Schwidder <schwidder@zib.de>
+ * @author      Maximilian Salomon <salomon@zib.de>
  * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */

--- a/tests/modules/admin/controllers/StatisticControllerTest.php
+++ b/tests/modules/admin/controllers/StatisticControllerTest.php
@@ -62,6 +62,7 @@ class Admin_StatisticControllerTest extends ControllerTestCase {
      * Fragt ab, ob bei einem falschen Jahr die Indexseite angezeigt wird
      */
     public function testIndexActionWithWrongYear() {
+        $this->useEnglish();
         $this->request
             ->setMethod('POST')
             ->setPost(array('selectedYear' => '1337'));

--- a/tests/modules/admin/forms/FileTest.php
+++ b/tests/modules/admin/forms/FileTest.php
@@ -27,7 +27,8 @@
  * @category    Application Unit Test
  * @package     Admin_Form
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2008-2017, OPUS 4 development team
+ * @author      Maximilian Salomon <salomon@zib.de>
+ * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 class Admin_Form_FileTest extends ControllerTestCase {

--- a/tests/modules/admin/forms/FileTest.php
+++ b/tests/modules/admin/forms/FileTest.php
@@ -48,6 +48,7 @@ class Admin_Form_FileTest extends ControllerTestCase {
     }
 
     public function testPopulateFromModel() {
+        $this->useEnglish();
         $form = new Admin_Form_File();
 
         $file = new Opus_File(126); // hängt an Testdokument 146

--- a/tests/modules/admin/forms/Person/ChangesTest.php
+++ b/tests/modules/admin/forms/Person/ChangesTest.php
@@ -197,6 +197,7 @@ class Admin_Form_Person_ChangesTest extends ControllerTestCase
 
     public function testRender()
     {
+        $this->useEnglish();
         $form = new Admin_Form_Person_Changes();
 
         $form->setOldValues(array(

--- a/tests/modules/admin/forms/Person/ChangesTest.php
+++ b/tests/modules/admin/forms/Person/ChangesTest.php
@@ -27,7 +27,8 @@
  * @category    Tests
  * @package     Admin_Form
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @author      Maximilian Salomon <salomon@zib.de>
+ * @copyright   Copyright (c) 2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 

--- a/tests/modules/solrsearch/controllers/IndexControllerTest.php
+++ b/tests/modules/solrsearch/controllers/IndexControllerTest.php
@@ -29,6 +29,7 @@
  * @author      Julian Heise <heise@zib.de>
  * @author      Sascha Szott <szott@zib.de>
  * @author      Jens Schwidder <schwidder@zib.de>
+ * @author      Maximilian Salomon <salomon@zib.de>
  * @copyright   Copyright (c) 2008-2018, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */

--- a/tests/modules/solrsearch/controllers/IndexControllerTest.php
+++ b/tests/modules/solrsearch/controllers/IndexControllerTest.php
@@ -587,6 +587,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
     }
 
     public function testUnavailableSolrServerReturns503() {
+        $this->useEnglish();
         $this->requireSolrConfig();
 
         // manipulate solr configuration


### PR DESCRIPTION
Some language-problems with german OS were solved. The tests uses in an german version also german messages, but expect english messages. So we add in all relevant tests the information, that opus have to use an english version instead the language of the system.