### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/modules/export/views/scripts/publist/default.xslt
+++ b/modules/export/views/scripts/publist/default.xslt
@@ -562,7 +562,7 @@
         <xsl:if test="@Type='doi'">
             <xsl:element name="a">
                 <xsl:attribute name="href">
-                    <xsl:text>http://dx.doi.org/</xsl:text>
+                    <xsl:text>https://doi.org/</xsl:text>
                     <xsl:value-of select="@Value" />
                 </xsl:attribute>
                 <xsl:text>DOI</xsl:text>

--- a/modules/export/views/scripts/stylesheets/ris.xslt
+++ b/modules/export/views/scripts/stylesheets/ris.xslt
@@ -267,7 +267,7 @@
     </xsl:template>
 	
 	<xsl:template match="IdentifierDoi">
-        <xsl:text>U6  - http://dx.doi.org/</xsl:text>
+        <xsl:text>U6  - https://doi.org/</xsl:text>
         <xsl:value-of select="@Value" />
         <xsl:text>&#10;</xsl:text>
     </xsl:template>

--- a/scripts/snippets/create_all_fields_document.php
+++ b/scripts/snippets/create_all_fields_document.php
@@ -144,7 +144,7 @@ $doc->addIdentifierOpac()->setValue('OPAC-ID 001 1237890654');
 $arxiv = $doc->addIdentifierArxiv();
 $arxiv->setValue('arXiv:0706.0001');
 
-// Valid DOI Identifier from DOI Homepage: http://www.doi.org/
+// Valid DOI Identifier from DOI Homepage: https://doi.org/
 $doi = $doc->addIdentifierDoi();
 $doi->setValue('10.1000/182');
 

--- a/tests/resources/xmetadissplus/doi.new.xsd
+++ b/tests/resources/xmetadissplus/doi.new.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DOI: complexType zu The Digital Object Identifier System siehe http://www.doi.org-->
+<!-- DOI: complexType zu The Digital Object Identifier System siehe https://doi.org-->
 <!-- Copyright 2010  Deutsche Nationalbibliothek -->
 <!-- Version xMetaDissPlus 2.1 -->
 <xs:schema targetNamespace="http://www.d-nb.de/standards/doi/" elementFormDefault="qualified"

--- a/tests/resources/xmetadissplus/doi.xsd
+++ b/tests/resources/xmetadissplus/doi.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- DOI: complexType zu The Digital Object Identifier System siehe http://www.doi.org-->
+<!-- DOI: complexType zu The Digital Object Identifier System siehe https://doi.org-->
 <!-- Copyright 2010  Deutsche Nationalbibliothek -->
 <!-- Version xMetaDissPlus 2.1 -->
 <xs:schema targetNamespace="http://www.d-nb.de/standards/doi/" elementFormDefault="qualified"


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update the code that generates new DOI links, plus switches a few static ones to https.

Cheers!