### PR TITLE
[OPUSVIER-3582] Angepasstes xslt, um die DOI in oai_dc anzuzeigen

### DIFF
--- a/modules/oai/views/scripts/index/prefixes/oai_dc.xslt
+++ b/modules/oai/views/scripts/index/prefixes/oai_dc.xslt
@@ -96,6 +96,7 @@
             </dc:identifier>
             <xsl:apply-templates select="IdentifierUrn" mode="oai_dc" />
             <xsl:apply-templates select="IdentifierIsbn" mode="oai_dc" />
+            <xsl:apply-templates select="IdentifierDoi" mode="oai_dc" />
             <xsl:apply-templates select="File" mode="oai_dc" />
             <!-- dc:language -->
             <xsl:apply-templates select="@Language" mode="oai_dc" />
@@ -334,6 +335,12 @@
         </dc:identifier>
         <dc:identifier>
             <xsl:value-of select="$urnResolverUrl" />
+            <xsl:value-of select="@Value" />
+        </dc:identifier>
+    </xsl:template>
+
+    <xsl:template match="IdentifierDoi" mode="oai_dc">
+        <dc:identifier>
             <xsl:value-of select="@Value" />
         </dc:identifier>
     </xsl:template>


### PR DESCRIPTION
Wir haben das gerade für einen Kunden gemacht. Soweit ich sehen konnte, war der Feature Request noch nicht erledigt. Ansonsten PR bitte ablehnen ;-) 