### PR TITLE
Feature OPUSVIER-4041 added. You can set "values" and "options" of HT…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
   apt:
     packages:
       - ant
+      - libxml2-utils
 cache:
   directories:
     - $HOME/.composer/cache

--- a/modules/publish/views/helpers/Fieldset.php
+++ b/modules/publish/views/helpers/Fieldset.php
@@ -100,6 +100,10 @@ class Publish_View_Helper_Fieldset extends Zend_View_Helper_Abstract {
         }
         $fieldset .= '>' . "\n\t\t\t\t\t";
 
+        if($options !== null) {
+            $field['options'] = $options;
+        }
+
         foreach ($field['options'] AS $key => $option) {
             $fieldset .= '<option value="' . htmlspecialchars($key, ENT_QUOTES) . '" label="'
                 . htmlspecialchars($option, ENT_QUOTES) . '"';


### PR DESCRIPTION
…ML option form elements in PHTML DocType templates dynamically now:

$valOptions = [
  'val1' => 'option1',
  'val2' => 'option2'
];
$this->group($this->groupFIELD_NAME, $valOptions);

If "values" and "options" was set statically in XML DocType templates it will be overridden.