### PR TITLE
Fixed path to Solr configuration files in install-solr.sh

### DIFF
--- a/bin/install-solr.sh
+++ b/bin/install-solr.sh
@@ -148,7 +148,7 @@ copyConfigFile "solrconfig.xml" "${BASEDIR}/vendor/opus4-repo/search" "${SOLR_CO
 
 # provide logging properties
 # TODO check integration of logging.properties with recent versions of solr
-ln -sf "$BASEDIR/vendor/opus4-repo/search/logging.properties" opus4/logging.properties
+ln -sf "$BASEDIR/vendor/opus4-repo/search/config/logging.properties" opus4/logging.properties
 
 # detect URL prefix to use
 case "$SOLR_MAJOR" in

--- a/bin/install-solr.sh
+++ b/bin/install-solr.sh
@@ -143,8 +143,8 @@ DST="${3}"
 # put configuration and schema files
 ln -sf  "$BASEDIR/vendor/opus4-repo/search/core.properties" "${SOLR_CORE_DIR}/data/solr"
 
-copyConfigFile "schema.xml" "${BASEDIR}/vendor/opus4-repo/search" "${SOLR_CORE_DIR}/data/solr/conf"
-copyConfigFile "solrconfig.xml" "${BASEDIR}/vendor/opus4-repo/search" "${SOLR_CORE_DIR}/data/solr/conf"
+copyConfigFile "schema.xml" "${BASEDIR}/vendor/opus4-repo/search/config" "${SOLR_CORE_DIR}/data/solr/conf"
+copyConfigFile "solrconfig.xml" "${BASEDIR}/vendor/opus4-repo/search/config" "${SOLR_CORE_DIR}/data/solr/conf"
 
 # provide logging properties
 # TODO check integration of logging.properties with recent versions of solr

--- a/bin/install-solr.sh
+++ b/bin/install-solr.sh
@@ -16,7 +16,7 @@
 # @license     http://www.gnu.org/licenses/gpl.html General Public License
 
 #
-# Downloads Apache Solr and runs the provides install script.
+# Downloads Apache Solr and runs the provided install script.
 #
 # Parameters:
 # 1) Port for new Solr server
@@ -64,13 +64,6 @@ fi
 [ -z "$SOLR_SERVER_PORT" ] && read -p "Solr server port number [8983]: " SOLR_SERVER_PORT
 SOLR_SERVER_PORT="${SOLR_SERVER_PORT:-8983}"
 
-# extract name of folder contained in archive
-SOLR_DIR="$(tar tzf "downloads/$SOLR_ARCHIVE_NAME" | head -1)"
-SOLR_DIR="${SOLR_DIR%%/*}"
-
-SOLR_VERSION="${SOLR_DIR#solr-}"
-SOLR_MAJOR="${SOLR_VERSION%%.*}"
-
 # stop any running solr service
 # TODO why?
 lsof -i ":$SOLR_SERVER_PORT" &>/dev/null && {
@@ -112,45 +105,18 @@ SOLR_CORE_DIR="$(pwd)/opus4"
 # create space for configuring solr service
 mkdir -p "${SOLR_CORE_DIR}/data/solr/conf"
 
-copyConfigFile() {
-NAME="${1}"
-SRC="${2}"
-DST="${3}"
-
-[ -e "${DST}/${NAME}" ] || {
-  PRE="${NAME%.*}"
-  POST="${NAME##*.}"
-
-  VERSION="${SOLR_VERSION}"
-
-  SRCNAME=
-  while [ -z "${SRCNAME}" -o \( ! -e "${SRCNAME}" -a -n "${VERSION}" \) ]
-  do
-    SRCNAME="${SRC}/${PRE}-${VERSION}.${POST}"
-    VERSION="${VERSION%.*}"
-  done
-
-  if [ -e "${SRCNAME}" ]; then
-    echo "setting up ${SRCNAME} as ${DST}/${NAME}"
-    ln -sf "${SRCNAME}" "${DST}/${NAME}"
-  else
-    echo "setting up ${SRC}/${NAME} as ${DST}/${NAME}"
-    ln -sf "${SRC}/${NAME}" "${DST}/${NAME}"
-  fi
-}
-}
-
 # put configuration and schema files
-ln -sf  "$BASEDIR/vendor/opus4-repo/search/core.properties" "${SOLR_CORE_DIR}/data/solr"
+ln -sf "$BASEDIR/vendor/opus4-repo/search/core.properties" "${SOLR_CORE_DIR}/data/solr"
 
-copyConfigFile "schema.xml" "${BASEDIR}/vendor/opus4-repo/search/config" "${SOLR_CORE_DIR}/data/solr/conf"
-copyConfigFile "solrconfig.xml" "${BASEDIR}/vendor/opus4-repo/search/config" "${SOLR_CORE_DIR}/data/solr/conf"
+cp "${BASEDIR}/vendor/opus4-repo/search/config/schema.xml" "${SOLR_CORE_DIR}/data/solr/conf"
+cp "${BASEDIR}/vendor/opus4-repo/search/config/solrconfig.xml" "${SOLR_CORE_DIR}/data/solr/conf"
 
 # provide logging properties
 # TODO check integration of logging.properties with recent versions of solr
 ln -sf "$BASEDIR/vendor/opus4-repo/search/config/logging.properties" opus4/logging.properties
 
 # detect URL prefix to use
+SOLR_MAJOR="${SOLR_VERSION%%.*}"
 case "$SOLR_MAJOR" in
 5)
   SOLR_CONTEXT="/solr/solr"


### PR DESCRIPTION
Scheinbar sind die Konfigurationsdateien nun in das Unterverzeichnis `config` gerutscht. Das führt dazu, dass `install-solr.sh` nicht mehr sauber funktioniert.

Zudem führt `install-solr.sh` bei Ausführung auf dem 4.6.4-Branch aufgrund von geänderten Dateinamensschema zu einer Endlosschleife in der Funktion `copyConfigFile`: die Funktion habe ich durch einfaches `cp` ersetzt, da wir im Paket `search` nun keine Versionsnummern mehr in die Namen der Solr-Konfigurationsdateien schreiben und daher die Funktion `copyConfigFile` zur Behandlung dieses Umstands obsolet geworden ist.

Die Variablen `SOLR_DIR`und `SOLR_VERSION` (redundant definiert) werden auch nicht mehr benötigt. Ich habe sie entfernt.

Funktionsfähigkeit des angepassten Script mit Solr 7.7.1 und OPUS-4.6.4-dev geprüft.