### PR TITLE
OPUSVIER-4122

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -445,27 +445,27 @@ model.plugins.document[] = 'Opus_Document_Plugin_IdentifierDoi'
 ; wie z.B. Google Scholar bereitgestellt.                              ;
 ;                                                                      ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-metatags.mapping.journal_paper[]=article
-metatags.mapping.journal_paper[]=contributiontoperiodical
-metatags.mapping.journal_paper[]=periodicalpart
-metatags.mapping.journal_paper[]=preprint
+metatags.defaultMapping.journal_paper[]=article
+metatags.defaultMapping.journal_paper[]=contributiontoperiodical
+metatags.defaultMapping.journal_paper[]=periodicalpart
+metatags.defaultMapping.journal_paper[]=preprint
 
-metatags.mapping.conference_paper[]=conferenceobject
+metatags.defaultMapping.conference_paper[]=conferenceobject
 
-metatags.mapping.thesis[]=bachelorthesis
-metatags.mapping.thesis[]=diplom
-metatags.mapping.thesis[]=doctoralthesis
-metatags.mapping.thesis[]=examen
-metatags.mapping.thesis[]=habilitation
-metatags.mapping.thesis[]=magister
-metatags.mapping.thesis[]=masterthesis
-metatags.mapping.thesis[]=studythesis
+metatags.defaultMapping.thesis[]=bachelorthesis
+metatags.defaultMapping.thesis[]=diplom
+metatags.defaultMapping.thesis[]=doctoralthesis
+metatags.defaultMapping.thesis[]=examen
+metatags.defaultMapping.thesis[]=habilitation
+metatags.defaultMapping.thesis[]=magister
+metatags.defaultMapping.thesis[]=masterthesis
+metatags.defaultMapping.thesis[]=studythesis
 
-metatags.mapping.working_paper[]=workingpaper
+metatags.defaultMapping.working_paper[]=workingpaper
 
-metatags.mapping.book[]=book
+metatags.defaultMapping.book[]=book
 
-metatags.mapping.book_part[]=bookpart
+metatags.defaultMapping.book_part[]=bookpart
 
 
 [staging : production]

--- a/modules/frontdoor/models/HtmlMetaTags.php
+++ b/modules/frontdoor/models/HtmlMetaTags.php
@@ -478,9 +478,16 @@ class Frontdoor_Model_HtmlMetaTags
      */
     private function isJournalPaper($document)
     {
+        if (isset($this->config, $this->config->metatags->defaultMapping->journal_paper)) {
+            if (in_array($document->getType(), $this->config->metatags->defaultMapping->journal_paper->toArray())) {
+                return true;
+            }
+        }
+        // Hinzufügen von Nicht-Standard-Dokumenttypen zum Mapping in config.ini
         if (isset($this->config, $this->config->metatags->mapping->journal_paper)) {
             return in_array($document->getType(), $this->config->metatags->mapping->journal_paper->toArray());
         }
+
         return false;
     }
 
@@ -490,6 +497,12 @@ class Frontdoor_Model_HtmlMetaTags
      */
     private function isConferencePaper($document)
     {
+        if (isset($this->config, $this->config->metatags->defaultMapping->conference_paper)) {
+            if (in_array($document->getType(), $this->config->metatags->defaultMapping->conference_paper->toArray())) {
+                return true;
+            }
+        }
+        // Hinzufügen von Nicht-Standard-Dokumenttypen zum Mapping in config.ini
         if (isset($this->config, $this->config->metatags->mapping->conference_paper)) {
             return in_array($document->getType(), $this->config->metatags->mapping->conference_paper->toArray());
         }
@@ -502,6 +515,12 @@ class Frontdoor_Model_HtmlMetaTags
      */
     private function isThesis($document)
     {
+        if (isset($this->config, $this->config->metatags->defaultMapping->thesis)) {
+            if (in_array($document->getType(), $this->config->metatags->defaultMapping->thesis->toArray())) {
+                return true;
+            }
+        }
+        // Hinzufügen von Nicht-Standard-Dokumenttypen zum Mapping in config.ini
         if (isset($this->config, $this->config->metatags->mapping->thesis)) {
             return in_array($document->getType(), $this->config->metatags->mapping->thesis->toArray());
         }
@@ -514,6 +533,12 @@ class Frontdoor_Model_HtmlMetaTags
      */
     private function isWorkingPaper($document)
     {
+        if (isset($this->config, $this->config->metatags->defaultMapping->working_paper)) {
+            if (in_array($document->getType(), $this->config->metatags->defaultMapping->working_paper->toArray())) {
+                return true;
+            }
+        }
+        // Hinzufügen von Nicht-Standard-Dokumenttypen zum Mapping in config.ini
         if (isset($this->config, $this->config->metatags->mapping->working_paper)) {
             return in_array($document->getType(), $this->config->metatags->mapping->working_paper->toArray());
         }
@@ -526,6 +551,12 @@ class Frontdoor_Model_HtmlMetaTags
      */
     private function isBook($document)
     {
+        if (isset($this->config, $this->config->metatags->defaultMapping->book)) {
+            if (in_array($document->getType(), $this->config->metatags->defaultMapping->book->toArray())) {
+                return true;
+            }
+        }
+        // Hinzufügen von Nicht-Standard-Dokumenttypen zum Mapping in config.ini
         if (isset($this->config, $this->config->metatags->mapping->book)) {
             return in_array($document->getType(), $this->config->metatags->mapping->book->toArray());
         }
@@ -538,6 +569,12 @@ class Frontdoor_Model_HtmlMetaTags
      */
     private function isBookPart($document)
     {
+        if (isset($this->config, $this->config->metatags->defaultMapping->book_part)) {
+            if (in_array($document->getType(), $this->config->metatags->defaultMapping->book_part->toArray())) {
+                return true;
+            }
+        }
+        // Hinzufügen von Nicht-Standard-Dokumenttypen zum Mapping in config.ini
         if (isset($this->config, $this->config->metatags->mapping->book_part)) {
             return in_array($document->getType(), $this->config->metatags->mapping->book_part->toArray());
         }

--- a/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
+++ b/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
@@ -639,6 +639,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         // hier bereits store aufrufen, weil wir die DocId für URN und DOI brauchen
         $docId = $doc->store();
 
+        $doc = new Opus_Document($docId);
         $this->addAuthors($doc, 3);
         $this->addTitles($doc);
         $this->addAbstracts($doc);

--- a/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
+++ b/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
@@ -55,12 +55,6 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $this->currDate = new Opus_Date(new Zend_Date());
     }
 
-    public function tearDown()
-    {
-        $this->deleteTempFiles();
-        parent::tearDown();
-    }
-
     public function testCreateTagsForMinimalDocument()
     {
         $doc = $this->createTestDocument();
@@ -198,7 +192,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertVolumeAndIssue($result);
         $this->assertIssn($result);
-        $this->assertInstitution($result, 'creatingCorporation');
+        $this->assertInstitution($result, 'crea');
     }
 
     public function testCreateTagsForWorkingPaperWithContributingCorporation()
@@ -231,7 +225,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $result = $this->htmlMetaTags->createTags($doc);
 
         // prüft nur, ob citation_technical_report_institution richtig gesetzt
-        $this->assertInstitution($result, 'contributingCorporation');
+        $this->assertInstitution($result, 'cont');
     }
 
     public function testCreateTagsForWorkingPaperWithPublisher()
@@ -621,6 +615,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     /**
      * @param string $docType
      * @return Opus_Document
+     * @throws Opus_Model_Exception
      */
     private function createTestDoc($docType)
     {
@@ -632,8 +627,8 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $doc->setIssue('issue');
         $doc->setPageFirst('pageFirst');
         $doc->setPageLast('pageLast');
-        $doc->setCreatingCorporation('creatingCorporation');
-        $doc->setContributingCorporation('contributingCorporation');
+        $doc->setCreatingCorporation('crea');
+        $doc->setContributingCorporation('cont');
         $doc->setPublishedDate($this->currDate);
         $doc->setServerState('published');
         // hier bereits store aufrufen, weil wir die DocId für URN und DOI brauchen

--- a/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
+++ b/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
@@ -310,6 +310,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     /**
      * @param array $tags
+     * @param int $docId
      */
     private function assertCommonIdentifiers($tags, $docId)
     {
@@ -341,6 +342,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     /**
      * @param array $tags
+     * @param int $docId
      */
     private function assertUrn($tags, $docId)
     {

--- a/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
+++ b/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
@@ -46,11 +46,6 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
      */
     private $currDate;
 
-    /**
-     * @var Opus_Document
-     */
-    private $testDoc;
-
     public function setUp()
     {
         parent::setUp();
@@ -62,21 +57,18 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function tearDown()
     {
-        if (! is_null($this->testDoc)) {
-            $this->testDoc->deletePermanent();
-        }
         $this->deleteTempFiles();
         parent::tearDown();
     }
 
     public function testCreateTagsForMinimalDocument()
     {
-        $this->testDoc = new Opus_Document();
-        $this->testDoc->setLanguage('deu');
-        $this->testDoc->setPublishedYear('2048');
-        $docId = $this->testDoc->store();
+        $doc = $this->createTestDocument();
+        $doc->setLanguage('deu');
+        $doc->setPublishedYear('2048');
+        $docId = $doc->store();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(8, $result);
         $this->assertContains(['DC.date', '2048'], $result);
@@ -91,10 +83,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForJournalPaper()
     {
-        $this->testDoc = $this->createJournalPaper();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createJournalPaper();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(59, $result);
         $this->assertCommonMetaTags($result, $docId);
@@ -106,10 +98,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForConferencePaper()
     {
-        $this->testDoc = $this->createConferencePaper();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createConferencePaper();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(59, $result);
         $this->assertCommonMetaTags($result, $docId);
@@ -121,23 +113,23 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForThesis()
     {
-        $this->testDoc = $this->createThesis();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createThesis();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(50, $result);
         $this->assertCommonMetaTags($result, $docId);
-        $this->assertThesisPublisher($result);
+        $this->assertThesisPublisher($doc, $result);
         $this->assertDocumentType($result);
     }
 
     public function testCreateTagsForWorkingPaper()
     {
-        $this->testDoc = $this->createWorkingPaper();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createWorkingPaper();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(55, $result);
         $this->assertCommonMetaTags($result, $docId);
@@ -148,11 +140,11 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForWorkingPaperWithContributingCorporation()
     {
-        $this->testDoc = $this->createWorkingPaper();
-        $this->testDoc->setCreatingCorporation('');
-        $this->testDoc->store();
+        $doc = $this->createWorkingPaper();
+        $doc->setCreatingCorporation('');
+        $doc->store();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         // prüft nur, ob citation_technical_report_institution richtig gesetzt
         $this->assertInstitution($result, 'contributingCorporation');
@@ -160,12 +152,12 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForWorkingPaperWithPublisher()
     {
-        $this->testDoc = $this->createWorkingPaper();
-        $this->testDoc->setCreatingCorporation('');
-        $this->testDoc->setContributingCorporation('');
-        $this->testDoc->store();
+        $doc = $this->createWorkingPaper();
+        $doc->setCreatingCorporation('');
+        $doc->setContributingCorporation('');
+        $doc->store();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         // prüft nur, ob citation_technical_report_institution richtig gesetzt
         $this->assertInstitution($result, 'publisherName');
@@ -173,10 +165,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForBook()
     {
-        $this->testDoc = $this->createBook();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createBook();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(49, $result);
         $this->assertCommonMetaTags($result, $docId);
@@ -185,10 +177,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForBookPart()
     {
-        $this->testDoc = $this->createBookPart();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createBookPart();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(53, $result);
         $this->assertCommonMetaTags($result, $docId);
@@ -198,10 +190,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     public function testCreateTagsForOther()
     {
-        $this->testDoc = $this->createOther();
-        $docId = $this->testDoc->getId();
+        $doc = $this->createOther();
+        $docId = $doc->getId();
 
-        $result = $this->htmlMetaTags->createTags($this->testDoc);
+        $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(49, $result);
         $this->assertCommonMetaTags($result, $docId);
@@ -218,13 +210,13 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $this->assertDates($tags);
         $this->assertMainTitles($tags);
         $this->assertPublisher($tags);
-        $this->assertCommonIdentifiers($tags);
+        $this->assertCommonIdentifiers($tags, $docId);
         $this->assertSubjects($tags);
         $this->assertLanguage($tags);
         $this->assertFile($tags, $docId);
         $this->assertFrontdoorUrl($tags, $docId);
         $this->assertAbstract($tags);
-        $this->assertUrn($tags);
+        $this->assertUrn($tags, $docId);
         $this->assertLicenceLink($tags);
     }
 
@@ -319,10 +311,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     /**
      * @param array $tags
      */
-    private function assertCommonIdentifiers($tags)
+    private function assertCommonIdentifiers($tags, $docId)
     {
-        $this->assertContains(['DC.identifier', 'doi'], $tags);
-        $this->assertContains(['citation_doi', 'doi'], $tags);
+        $this->assertContains(['DC.identifier', 'doi' . $docId], $tags);
+        $this->assertContains(['citation_doi', 'doi' . $docId], $tags);
 
         $this->assertContains(['DC.identifier', 'isbn'], $tags);
         $this->assertContains(['citation_isbn', 'isbn'], $tags);
@@ -350,10 +342,10 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     /**
      * @param array $tags
      */
-    private function assertUrn($tags)
+    private function assertUrn($tags, $docId)
     {
-        $this->assertContains(['DC.identifier', 'urn'], $tags);
-        $this->assertContains(['DC.identifier', 'https://nbn-resolving.org/urn'], $tags);
+        $this->assertContains(['DC.identifier', 'urn' . $docId], $tags);
+        $this->assertContains(['DC.identifier', 'https://nbn-resolving.org/urn' . $docId], $tags);
     }
 
     /**
@@ -419,11 +411,12 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     }
 
     /**
+     * @param Opus_Document $doc
      * @param array $tags
      */
-    private function assertThesisPublisher($tags)
+    private function assertThesisPublisher($doc, $tags)
     {
-        $thesisPublisher = $this->testDoc->getThesisPublisher();
+        $thesisPublisher = $doc->getThesisPublisher();
         $publisherName = $thesisPublisher[0]->getModel()->getName();
         $this->assertContains(['DC.publisher', $publisherName], $tags);
         $this->assertContains(['citation_dissertation_institution', $publisherName], $tags);
@@ -490,7 +483,7 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
      */
     private function createTestDoc($docType)
     {
-        $doc = new Opus_Document();
+        $doc = $this->createTestDocument();
         $doc->setType($docType);
         $doc->setLanguage('deu');
         $doc->setPublisherName('publisherName');
@@ -502,6 +495,8 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $doc->setContributingCorporation('contributingCorporation');
         $doc->setPublishedDate($this->currDate);
         $doc->setServerState('published');
+        // hier bereits store aufrufen, weil wir die DocId für URN und DOI brauchen
+        $docId = $doc->store();
 
         $this->addAuthors($doc, 3);
         $this->addTitles($doc);
@@ -511,8 +506,8 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $this->addFile($doc);
         $this->addThesisPublisher($doc);
         $this->addLicence($doc);
+        $doc->store();
 
-        $docId = $doc->store();
         return new Opus_Document($docId);
     }
 
@@ -608,12 +603,12 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
         $identifer = new Opus_Identifier();
         $identifer->setType('doi');
-        $identifer->setValue('doi');
+        $identifer->setValue('doi' . $doc->getId());
         $identifers[] = $identifer;
 
         $identifer = new Opus_Identifier();
         $identifer->setType('urn');
-        $identifer->setValue('urn');
+        $identifer->setValue('urn' . $doc->getId());
         $identifers[] = $identifer;
 
         $identifer = new Opus_Identifier();

--- a/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
+++ b/tests/modules/frontdoor/models/HtmlMetaTagsTest.php
@@ -84,12 +84,28 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     public function testCreateTagsForJournalPaper()
     {
         $doc = $this->createJournalPaper();
-        $docId = $doc->getId();
+        $this->handleJournalPaper($doc);
+    }
 
+    public function testCreateTagsForCustomTypeJournalPaper()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['journal_paper' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $this->handleJournalPaper($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleJournalPaper($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(59, $result);
-        $this->assertCommonMetaTags($result, $docId);
+        $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertParentTitle($result, 'journal');
         $this->assertVolumeAndIssue($result);
         $this->assertPages($result);
@@ -99,12 +115,28 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     public function testCreateTagsForConferencePaper()
     {
         $doc = $this->createConferencePaper();
-        $docId = $doc->getId();
+        $this->handleConferencePaper($doc);
+    }
 
+    public function testCreateTagsForCustomTypeConferencePaper()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['conference_paper' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $this->handleConferencePaper($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleConferencePaper($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(59, $result);
-        $this->assertCommonMetaTags($result, $docId);
+        $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertParentTitle($result, 'conference');
         $this->assertVolumeAndIssue($result);
         $this->assertPages($result);
@@ -114,25 +146,56 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     public function testCreateTagsForThesis()
     {
         $doc = $this->createThesis();
-        $docId = $doc->getId();
+        $this->handleThesis($doc);
+    }
 
+    public function testCreateTagsForCustomTypeThesis()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['thesis' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $this->handleThesis($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleThesis($doc) {
         $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(50, $result);
-        $this->assertCommonMetaTags($result, $docId);
+        $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertThesisPublisher($doc, $result);
-        $this->assertDocumentType($result);
+        $this->assertDocumentType($result, $doc->getType());
     }
 
     public function testCreateTagsForWorkingPaper()
     {
         $doc = $this->createWorkingPaper();
-        $docId = $doc->getId();
+        $this->handleWorkingPaper($doc);
+    }
 
+    public function testCreateTagsForCustomTypeWorkingPaper()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['working_paper' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $this->handleWorkingPaper($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleWorkingPaper($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(55, $result);
-        $this->assertCommonMetaTags($result, $docId);
+        $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertVolumeAndIssue($result);
         $this->assertIssn($result);
         $this->assertInstitution($result, 'creatingCorporation');
@@ -144,6 +207,27 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $doc->setCreatingCorporation('');
         $doc->store();
 
+        $this->handleWorkingPaperWithContributingCorporation($doc);
+    }
+
+    public function testCreateTagsForCustomTypeWorkingPaperWithContributingCorporation()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['working_paper' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $doc->setCreatingCorporation('');
+        $doc->store();
+
+        $this->handleWorkingPaperWithContributingCorporation($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleWorkingPaperWithContributingCorporation($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         // prüft nur, ob citation_technical_report_institution richtig gesetzt
@@ -157,6 +241,28 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
         $doc->setContributingCorporation('');
         $doc->store();
 
+        $this->handleWorkingPaperWithPublisher($doc);
+    }
+
+    public function testCreateTagsForCustomTypeWorkingPaperWithPublisher()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['working_paper' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $doc->setCreatingCorporation('');
+        $doc->setContributingCorporation('');
+        $doc->store();
+
+        $this->handleWorkingPaperWithPublisher($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleWorkingPaperWithPublisher($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         // prüft nur, ob citation_technical_report_institution richtig gesetzt
@@ -166,24 +272,56 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
     public function testCreateTagsForBook()
     {
         $doc = $this->createBook();
-        $docId = $doc->getId();
+        $this->handleBook($doc);
+    }
 
+    public function testCreateTagsForCustomTypeBook()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['book' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $this->handleBook($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleBook($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(49, $result);
-        $this->assertCommonMetaTags($result, $docId);
+        $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertParentTitle($result, 'inbook');
     }
 
     public function testCreateTagsForBookPart()
     {
         $doc = $this->createBookPart();
-        $docId = $doc->getId();
+        $this->handleBookPart($doc);
+    }
 
+    public function testCreateTagsForCustomTypeBookPart()
+    {
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
+            ['metatags' => ['mapping' => ['book_part' => ['customdoctype']]]]
+        ));
+
+        $doc = $this->createTestDoc('customdoctype');
+        $this->handleBookPart($doc);
+    }
+
+    /**
+     * @param Opus_Document $doc
+     */
+    private function handleBookPart($doc)
+    {
         $result = $this->htmlMetaTags->createTags($doc);
 
         $this->assertCount(53, $result);
-        $this->assertCommonMetaTags($result, $docId);
+        $this->assertCommonMetaTags($result, $doc->getId());
         $this->assertPages($result);
         $this->assertParentTitle($result, 'inbook');
     }
@@ -426,10 +564,11 @@ class Frontdoor_Model_HtmlMetaTagsTest extends ControllerTestCase
 
     /**
      * @param array $tags
+     * @param string $docType
      */
-    private function assertDocumentType($tags)
+    private function assertDocumentType($tags, $docType)
     {
-        $this->assertContains(['citation_dissertation_name', 'bachelorthesis'], $tags);
+        $this->assertContains(['citation_dissertation_name', $docType], $tags);
     }
 
     /**


### PR DESCRIPTION
Das Metatags-Default-Mapping (in `application.ini`) kann nun selektiv verändert werden, indem für Nicht-Standard-Dokumenttypen in der `config.ini` entsprechende Custom-Mappings angegeben werden können. Dabei werden die Default-Mappings für die in OPUS4 eingebauten Dokumenttypen nicht überschrieben.