### PR TITLE
OPUSVIER-4112

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -190,7 +190,7 @@ clearing.addPersonReferee = 1 ; Turn on (= 1) to add a PersonReferee when publis
 clearing.addCurrentUserAsReferee = 0 ; Turn on (= 1) to set logged in user that switches document to published as PersonReferee
 
 ;ACCOUNT MODULE SETTINGS
-account.changeLogin = 1; Turn on to allow users to change their own account login
+account.changeLogin = 1 ; Turn on to allow users to change their own account login
 account.editOwnAccount = 1 ; Turn on to allow users to edit their own account information
 account.editPasswordOnly = 0 ; Turn on to restrict editing to just the password
 

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -59,8 +59,8 @@ autoloaderNamespaces.app = 'Application_'
 resources.modules[] = ""
 resources.frontController.moduleDirectory = APPLICATION_PATH "/modules"
 resources.frontController.params.displayExceptions = 0
-resources.frontController.throwExceptions=0
-resources.frontController.returnResponse=0
+resources.frontController.throwExceptions = 0
+resources.frontController.returnResponse = 0
 
 ; DATABASE PROFILER - set to 1 to enable profiling (i.e. stacktrace on every db-connect)
 db.debug = 0

--- a/library/Application/Bootstrap.php
+++ b/library/Application/Bootstrap.php
@@ -315,7 +315,7 @@ class Application_Bootstrap extends Opus_Bootstrap_Base
 
         $config = $this->getResource('configuration');
 
-        if (isset($config->security) && $config->security == 1) {
+        if (isset($config->security) && filter_var($config->security, FILTER_VALIDATE_BOOLEAN)) {
             Application_Security_AclProvider::init();
         } else {
             Zend_View_Helper_Navigation_HelperAbstract::setDefaultAcl(null);

--- a/library/Application/Export/ExportPluginAbstract.php
+++ b/library/Application/Export/ExportPluginAbstract.php
@@ -140,9 +140,8 @@ abstract class Application_Export_ExportPluginAbstract extends Application_Model
      */
     public function isAccessRestricted()
     {
-        $adminOnlyAccess = $this->getConfig()->adminOnly;
-        // TODO OPUSVIER-4112 move handling of boolean configuration parameters to base helper class
-        if (isset($adminOnlyAccess) && $adminOnlyAccess == '1') {
+        if (isset($this->getConfig()->adminOnly) &&
+            filter_var($this->getConfig()->adminOnly, FILTER_VALIDATE_BOOLEAN)) {
             return ! Opus_Security_Realm::getInstance()->checkModule('admin');
         }
         return false; // keine Einschränkung des Zugriffs

--- a/library/Application/Translate.php
+++ b/library/Application/Translate.php
@@ -233,12 +233,13 @@ class Application_Translate extends Zend_Translate
 
     /**
      *
-     * @return type
+     * @return bool
      */
     public function isLogUntranslatedEnabled()
     {
         $config = Zend_Registry::get('Zend_Config');
-        return (isset($config->log->untranslated)) ? (bool)$config->log->untranslated : false;
+        return (isset($config->log->untranslated)) ?
+            filter_var($config->log->untranslated, FILTER_VALIDATE_BOOLEAN) : false;
     }
 
     /**

--- a/library/Application/Util/Notification.php
+++ b/library/Application/Util/Notification.php
@@ -141,6 +141,7 @@ class Application_Util_Notification extends Application_Model_Abstract
     }
 
     /**
+     * @param $document Opus_Document
      * @param $docId
      * @param $authors
      * @param $title
@@ -184,7 +185,6 @@ class Application_Util_Notification extends Application_Model_Abstract
     public function getSubjectTemplate()
     {
         $config = $this->getConfig();
-
         if (isset($config->notification->document->submitted->subject)) {
             return $config->notification->document->submitted->subject;
         }
@@ -193,7 +193,6 @@ class Application_Util_Notification extends Application_Model_Abstract
     public function getMailBody($docId, $authors, $title, $url)
     {
         $config = $this->getConfig();
-
         if (isset($config->notification->document->submitted->template)) {
             return $this->getTemplate(
                 $config->notification->document->submitted->template,
@@ -271,7 +270,7 @@ class Application_Util_Notification extends Application_Model_Abstract
         $config = $this->getConfig();
 
         return isset($config->notification->document->published->enabled)
-                && $config->notification->document->published->enabled == 1;
+                && filter_var($config->notification->document->published->enabled, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
@@ -305,7 +304,8 @@ class Application_Util_Notification extends Application_Model_Abstract
 
                 $config = $this->getConfig();
 
-                if (isset($config->runjobs->asynchronous) && $config->runjobs->asynchronous) {
+                if (isset($config->runjobs->asynchronous) &&
+                    filter_var($config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
                     // Queue job (execute asynchronously)
                     // skip creating job if equal job already exists
                     if (true === $job->isUniqueInQueue()) {

--- a/library/Application/Util/PublicationNotification.php
+++ b/library/Application/Util/PublicationNotification.php
@@ -106,15 +106,13 @@ class Application_Util_PublicationNotification extends Application_Util_Notifica
     public function isEnabled()
     {
         $config = $this->getConfig();
-
         return isset($config->notification->document->published->enabled)
-            && $config->notification->document->published->enabled == 1;
+            && filter_var($config->notification->document->published->enabled, FILTER_VALIDATE_BOOLEAN);
     }
 
     public function getSubjectTemplate()
     {
         $config = $this->getConfig();
-
         if (isset($config->notification->document->published->subject)) {
             return $config->notification->document->published->subject;
         }

--- a/library/Application/View/Helper/CustomFileSortingEnabled.php
+++ b/library/Application/View/Helper/CustomFileSortingEnabled.php
@@ -34,7 +34,6 @@
 
 class Application_View_Helper_CustomFileSortingEnabled extends Zend_View_Helper_Abstract
 {
-
     /**
      * Check if custom file sorting based on sort order field is enabled.
      *
@@ -42,6 +41,8 @@ class Application_View_Helper_CustomFileSortingEnabled extends Zend_View_Helper_
      */
     public function customFileSortingEnabled()
     {
-        return Zend_Registry::get('Zend_Config')->frontdoor->files->customSorting == '1';
+        $config = Zend_Registry::get('Zend_Config');
+        return isset($config->frontdoor->files->customSorting) &&
+            filter_var($config->frontdoor->files->customSorting, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/library/Application/View/Helper/Document/HelperAbstract.php
+++ b/library/Application/View/Helper/Document/HelperAbstract.php
@@ -36,7 +36,6 @@
  */
 abstract class Application_View_Helper_Document_HelperAbstract extends Application_View_Helper_Abstract
 {
-
     /**
      * Determines if preferably the title matching the user interface language should be used.
      * @var bool
@@ -52,13 +51,8 @@ abstract class Application_View_Helper_Document_HelperAbstract extends Applicati
         $config = $this->getConfig();
 
         if (is_null($this->_preferUserInterfaceLanguage)) {
-            if (isset($config->search->result->display->preferUserInterfaceLanguage)) {
-                $value = trim($config->search->result->display->preferUserInterfaceLanguage);
-
-                $this->_preferUserInterfaceLanguage = ($value == 1 || $value === 'true');
-            } else {
-                $this->_preferUserInterfaceLanguage = false;
-            }
+            $this->_preferUserInterfaceLanguage = isset($config->search->result->display->preferUserInterfaceLanguage) &&
+                filter_var($config->search->result->display->preferUserInterfaceLanguage, FILTER_VALIDATE_BOOLEAN);
         }
 
         return $this->_preferUserInterfaceLanguage;
@@ -70,6 +64,6 @@ abstract class Application_View_Helper_Document_HelperAbstract extends Applicati
      */
     public function setPreferUserInterfaceLanguage($enabled)
     {
-        $this->_preferUserInterfaceLanguage = ($enabled == 1 || $enabled === 'true');
+        $this->_preferUserInterfaceLanguage = filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/library/Application/View/Helper/LoginBar.php
+++ b/library/Application/View/Helper/LoginBar.php
@@ -132,7 +132,7 @@ class Application_View_Helper_LoginBar extends Zend_View_Helper_Abstract
             // Prüfe, ob Nutzer ihren Account editieren dürfen
             $config = Zend_Registry::get('Zend_Config');
             if (isset($config) and isset($config->account->editOwnAccount)) {
-                $addAccountLink = $config->account->editOwnAccount;
+                $addAccountLink = filter_var($config->account->editOwnAccount, FILTER_VALIDATE_BOOLEAN);
             }
         }
 

--- a/library/Application/View/Helper/OptionEnabled.php
+++ b/library/Application/View/Helper/OptionEnabled.php
@@ -53,6 +53,6 @@ class Application_View_Helper_OptionEnabled extends Application_View_Helper_Abst
 
         $value = Application_Configuration::getInstance()->getValue($key);
 
-        return $value === 'true' or $value == '1';
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/modules/account/controllers/IndexController.php
+++ b/modules/account/controllers/IndexController.php
@@ -114,8 +114,8 @@ class Account_IndexController extends Application_Controller_Action
 
             // check if username was provided and if it may be changed
             if (! isset($postData['username'])
-                    || (isset($config->account->editPasswordOnly) && $config->account->editPasswordOnly)
-                    || (isset($config->account->changeLogin) && ! $config->account->changeLogin)) {
+                    || (isset($config->account->editPasswordOnly) && filter_var($config->account->editPasswordOnly, FILTER_VALIDATE_BOOLEAN))
+                    || (isset($config->account->changeLogin) && (! filter_var($config->account->changeLogin, FILTER_VALIDATE_BOOLEAN)))) {
                 $postData['username'] = $login;
             }
 
@@ -132,7 +132,7 @@ class Account_IndexController extends Application_Controller_Action
 
                 $isLoginChanged = false;
 
-                if (isset($config->account->editPasswordOnly) && ! $config->account->editPasswordOnly) {
+                if (isset($config->account->editPasswordOnly) && (! filter_var($config->account->editPasswordOnly, FILTER_VALIDATE_BOOLEAN))) {
                     $account->setFirstName($firstname);
                     $account->setLastName($lastname);
                     $account->setEmail($email);

--- a/modules/account/controllers/IndexController.php
+++ b/modules/account/controllers/IndexController.php
@@ -54,7 +54,7 @@ class Account_IndexController extends Application_Controller_Action
             return false;
         }
 
-        return $parentValue and $config->account->editOwnAccount;
+        return $parentValue && filter_var($config->account->editOwnAccount, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/modules/account/forms/Account.php
+++ b/modules/account/forms/Account.php
@@ -90,12 +90,13 @@ class Account_Form_Account extends Application_Form_Model_Abstract
         $this->getElement('lastname')->setValue($account->getLastName());
         $this->getElement('email')->setValue($account->getEmail());
 
-        if (isset($config->account->editPasswordOnly) && $config->account->editPasswordOnly) {
+        if (isset($config->account->editPasswordOnly) && filter_var($config->account->editPasswordOnly, FILTER_VALIDATE_BOOLEAN)) {
             $this->getElement('username')->setAttrib('disabled', true);
             $this->getElement('firstname')->setAttrib('disabled', true);
             $this->getElement('lastname')->setAttrib('disabled', true);
             $this->getElement('email')->setAttrib('disabled', true);
-        } elseif (isset($config->account->changeLogin) && ! $config->account->changeLogin) {
+        } elseif (isset($config->account->changeLogin) &&
+            (! filter_var($config->account->changeLogin, FILTER_VALIDATE_BOOLEAN))) {
             $this->getElement('username')->setAttrib('disabled', true);
         }
 

--- a/modules/admin/controllers/DocumentsController.php
+++ b/modules/admin/controllers/DocumentsController.php
@@ -66,12 +66,8 @@ class Admin_DocumentsController extends Application_Controller_Action
         parent::init();
 
         $config = $this->getConfig();
-
-        if (isset($config->admin->documents->linkToAuthorSearch)) {
-            $this->view->linkToAuthorSearch = $config->admin->documents->linkToAuthorSearch;
-        } else {
-            $this->view->linkToAuthorSearch = 0;
-        }
+        $this->view->linkToAuthorSearch = isset($config->admin->documents->linkToAuthorSearch) &&
+            filter_var($config->admin->documents->linkToAuthorSearch, FILTER_VALIDATE_BOOLEAN);
 
         if (isset($config->admin->documents->maxDocsDefault)) {
             $this->_maxDocsDefault = $config->admin->documents->maxDocsDefault;

--- a/modules/admin/controllers/JobController.php
+++ b/modules/admin/controllers/JobController.php
@@ -43,7 +43,7 @@ class Admin_JobController extends Application_Controller_Action
 
         $config = $this->getConfig();
 
-        if (isset($config->runjobs->asynchronous) && $config->runjobs->asynchronous) {
+        if (isset($config->runjobs->asynchronous) && filter_var($config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
             $this->view->asyncjobs = true;
             $this->view->failedJobCount = Opus_Job::getCountPerLabel(Opus_Job::STATE_FAILED);
             $this->view->unprocessedJobCount = Opus_Job::getCountPerLabel(Opus_Job::STATE_UNDEFINED);
@@ -65,7 +65,7 @@ class Admin_JobController extends Application_Controller_Action
     {
         $config = $this->getConfig();
         $this->_helper->layout()->disableLayout();
-        if (isset($config->runjobs->asynchronous) && $config->runjobs->asynchronous) {
+        if (isset($config->runjobs->asynchronous) && filter_var($config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
             $this->view->failedJobCount = Opus_Job::getCount(Opus_Job::STATE_FAILED);
         } else {
             $this->view->failedJobCount = 0;

--- a/modules/admin/controllers/WorkflowController.php
+++ b/modules/admin/controllers/WorkflowController.php
@@ -70,7 +70,7 @@ class Admin_WorkflowController extends Application_Controller_Action
         $config = $this->getConfig();
 
         if (isset($config->confirmation->document->statechange->enabled)) {
-            $this->_confirmChanges = ($config->confirmation->document->statechange->enabled == 1) ? true : false;
+            $this->_confirmChanges = filter_var($config->confirmation->document->statechange->enabled, FILTER_VALIDATE_BOOLEAN);
         } else {
             $this->_confirmChanges = true;
         }

--- a/modules/admin/forms/Document/MultiIdentifierSubForm.php
+++ b/modules/admin/forms/Document/MultiIdentifierSubForm.php
@@ -228,10 +228,12 @@ class Admin_Form_Document_MultiIdentifierSubForm extends Admin_Form_Document_Mul
         $config = $this->getApplicationConfig();
         switch ($this->_typeShort) {
             case 'doi':
-                $autoGenerateCheckbox->setChecked($config->doi->autoCreate || $config->doi->autoCreate == '1');
+                $checkboxValue = isset($config->doi->autoCreate) && filter_var($config->doi->autoCreate, FILTER_VALIDATE_BOOLEAN);
+                $autoGenerateCheckbox->setChecked($checkboxValue);
                 break;
             case 'urn':
-                $autoGenerateCheckbox->setChecked($config->urn->autoCreate || $config->urn->autoCreate == '1');
+                $checkboxValue = isset($config->urn->autoCreate) && filter_var($config->urn->autoCreate, FILTER_VALIDATE_BOOLEAN);
+                $autoGenerateCheckbox->setChecked($checkboxValue);
                 break;
         }
     }

--- a/modules/admin/forms/WorkflowNotification.php
+++ b/modules/admin/forms/WorkflowNotification.php
@@ -65,9 +65,8 @@ class Admin_Form_WorkflowNotification extends Admin_Form_YesNoForm
     public function isNotificationEnabled()
     {
         $config = Zend_Registry::get('Zend_Config');
-
-        return ((isset($config->notification->document->published->enabled)
-            && $config->notification->document->published->enabled == 1));
+        return (isset($config->notification->document->published->enabled)
+            && filter_var($config->notification->document->published->enabled, FILTER_VALIDATE_BOOLEAN));
     }
 
     /**

--- a/modules/admin/models/IndexMaintenance.php
+++ b/modules/admin/models/IndexMaintenance.php
@@ -65,9 +65,9 @@ class Admin_Model_IndexMaintenance
     {
         $this->_featureDisabled = ! (
                 (isset($this->_config->runjobs->indexmaintenance->asynchronous)
-                    && $this->_config->runjobs->indexmaintenance->asynchronous) ||
+                    && filter_var($this->_config->runjobs->indexmaintenance->asynchronous, FILTER_VALIDATE_BOOLEAN)) ||
                 (! isset($this->_config->runjobs->indexmaintenance->asynchronous)
-                    && isset($this->_config->runjobs->asynchronous) && $this->_config->runjobs->asynchronous));
+                    && isset($this->_config->runjobs->asynchronous) && filter_var($this->_config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)));
     }
 
     public function getFeatureDisabled()

--- a/modules/default/controllers/ErrorController.php
+++ b/modules/default/controllers/ErrorController.php
@@ -99,8 +99,8 @@ class ErrorController extends Application_Controller_Action
             return;
         }
 
-        $this->view->showException = $errorConfig->showException;
-        if ($errorConfig->showRequest) {
+        $this->view->showException = filter_var($errorConfig->showException, FILTER_VALIDATE_BOOLEAN);
+        if (isset($errorConfig->showRequest) && filter_var($errorConfig->showRequest, FILTER_VALIDATE_BOOLEAN)) {
             $this->view->errorRequest = $errors->request;
         }
 

--- a/modules/export/models/PublistExport.php
+++ b/modules/export/models/PublistExport.php
@@ -99,7 +99,7 @@ class Export_Model_PublistExport extends Export_Model_XsltExport
 
         // TODO config
         $groupBy = 'publishedYear';
-        // TODO config does not make sense - completely ignores value of setting
+        // FIXME OPUSVIER-4130 config does not make sense - completely ignores value of setting
         if (isset($config->groupby->completedyear)) {
             $groupBy = 'completedYear';
         }

--- a/modules/export/models/XmlExport.php
+++ b/modules/export/models/XmlExport.php
@@ -28,7 +28,7 @@
  * @package     Module_Export
  * @author      Michael Lang <lang@zib.de>
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2008-2017, OPUS 4 development team
+ * @copyright   Copyright (c) 2008-2019, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 
@@ -164,12 +164,8 @@ class Export_Model_XmlExport extends Application_Export_ExportPluginAbstract
         if (is_null($this->_downloadEnabled)) {
             $appConfig = Application_Configuration::getInstance()->getConfig();
 
-            if (isset($appConfig->export->download)) {
-                $value = $appConfig->export->download;
-                $this->_downloadEnabled = $value !== '0' && $value !== false && $value !== '';
-            } else {
-                $this->_downloadEnabled = true;
-            }
+            $this->_downloadEnabled = isset($appConfig->export->download) ?
+                filter_var($appConfig->export->download, FILTER_VALIDATE_BOOLEAN) : true;
         }
 
         return $this->_downloadEnabled;

--- a/modules/export/models/XsltExport.php
+++ b/modules/export/models/XsltExport.php
@@ -61,9 +61,9 @@ class Export_Model_XsltExport extends Export_Model_XmlExport
             )
         );
 
-        // TODO OPUSVIER-4112 move handling of boolean configuration parameters to base helper class
         $restrictExportToPublishedDocuments =
-            ! (isset($config->restrictExportToPublishedDocuments) && $config->restrictExportToPublishedDocuments == '');
+            ! (isset($config->restrictExportToPublishedDocuments) &&
+                (! filter_var($config->restrictExportToPublishedDocuments, FILTER_VALIDATE_BOOLEAN)));
         $this->prepareXml($restrictExportToPublishedDocuments);
     }
 }

--- a/modules/home/controllers/IndexController.php
+++ b/modules/home/controllers/IndexController.php
@@ -150,11 +150,8 @@ class Home_IndexController extends Application_Controller_Action
     public function helpAction()
     {
         $config = $this->getConfig();
-        if (isset($config->help->separate)) {
-            $this->view->separate = (boolean) $config->help->separate;
-        } else {
-            $this->view->separate = false;
-        }
+        $this->view->separate = isset($config->help->separate) &&
+            filter_var($config->help->separate, FILTER_VALIDATE_BOOLEAN);
 
         if ($this->view->separate) {
             $content = $this->getRequest()->getParam('content');

--- a/modules/publish/controllers/FormController.php
+++ b/modules/publish/controllers/FormController.php
@@ -394,7 +394,8 @@ class Publish_FormController extends Application_Controller_Action
      */
     private function _storeBibliography($data, $config)
     {
-        if (! isset($config->form->first->bibliographie) || $config->form->first->bibliographie != '1') {
+        if (! isset($config->form->first->bibliographie) ||
+            ! filter_var($config->form->first->bibliographie, FILTER_VALIDATE_BOOLEAN)) {
             return;
         }
 

--- a/modules/publish/forms/PublishingFirst.php
+++ b/modules/publish/forms/PublishingFirst.php
@@ -224,8 +224,7 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
             $bibliographie = $this->createElement('checkbox', 'bibliographie');
             $bibliographie->setDisableTranslator(true);
             $bibliographie->setLabel('bibliographie');
-        }
-        else {
+        } else {
             $this->bibliographie = 0;
             $bibliographie = null;
         }
@@ -244,8 +243,7 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
                 ->setLabel('rights')
                 ->setRequired(true)
                 ->setChecked(false);
-        }
-        else {
+        } else {
             $this->showRights = 0;
             $rightsCheckbox = null;
         }

--- a/modules/publish/forms/PublishingFirst.php
+++ b/modules/publish/forms/PublishingFirst.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -58,7 +57,8 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
     {
         $valid = parent::isValid($data);
 
-        if ($this->_config->form->first->show_rights_checkbox == 1) {
+        if (isset($this->_config->form->first->show_rights_checkbox) &&
+            filter_var($this->_config->form->first->show_rights_checkbox, FILTER_VALIDATE_BOOLEAN)) {
             if (array_key_exists('rights', $data)) {
                 if ($data['rights'] == '0') {
                     $rights = $this->getElement('rights');
@@ -88,7 +88,8 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
         $this->addElement($doctypes);
 
         //create and add file upload
-        $this->enableUpload = ($this->_config->form->first->enable_upload == 1);
+        $this->enableUpload = isset($this->_config->form->first->enable_upload) &&
+            filter_var($this->_config->form->first->enable_upload, FILTER_VALIDATE_BOOLEAN);
         if ($this->enableUpload) {
             $fileupload = $this->_createFileuploadField();
             $this->addDisplayGroup($fileupload, 'documentUpload');
@@ -164,12 +165,6 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
             $maxFileSize = 1024000; //1MB
         }
 
-        // Upload-fields required to enter second stage
-        $requireUpload = $this->_config->form->first->require_upload;
-        if (true === empty($requireUpload)) {
-            $requireUpload = 0;
-        }
-
         //initialization of filename-validator
         $filenameMaxLength = $this->_config->publish->filenameMaxLength;
         $filenameFormat = $this->_config->publish->filenameFormat;
@@ -192,8 +187,11 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
                 ->addValidator($filenameValidator, false)       // filename-format
                 ->setAttrib('enctype', 'multipart/form-data');
 
-        if (1 == $requireUpload) {
+        // Upload-fields required to enter second stage
+        if (isset($this->_config->form->first->require_upload) &&
+            filter_var($this->_config->form->first->require_upload, FILTER_VALIDATE_BOOLEAN)) {
             if (! isset($this->_session->fulltext) || $this->_session->fulltext == '0') {
+                // noch keine Datei zum Upload ausgewählt
                 $fileupload->setRequired(true);
             }
         } else {
@@ -220,19 +218,16 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
      */
     private function _createBibliographyField()
     {
-        $bib = $this->_config->form->first->bibliographie;
-        if (true === empty($bib)) {
-            $bib = 0;
-            $this->bibliographie = 0;
-        }
-
-        $bibliographie = null;
-
-        if ($bib == 1) {
+        if (isset($this->_config->form->first->bibliographie) &&
+            filter_var($this->_config->form->first->bibliographie, FILTER_VALIDATE_BOOLEAN)) {
             $this->bibliographie = 1;
             $bibliographie = $this->createElement('checkbox', 'bibliographie');
             $bibliographie->setDisableTranslator(true);
             $bibliographie->setLabel('bibliographie');
+        }
+        else {
+            $this->bibliographie = 0;
+            $bibliographie = null;
         }
 
         return $bibliographie;
@@ -240,22 +235,19 @@ class Publish_Form_PublishingFirst extends Publish_Form_PublishingAbstract
 
     private function _createRightsCheckBox()
     {
-        $showRights = $this->_config->form->first->show_rights_checkbox;
-        if (true === empty($showRights)) {
-            $showRights = 0;
-            $this->showRights = 0;
-        }
-
-        $rightsCheckbox = null;
-
-        if ($showRights == 1) {
+        if (isset($this->_config->form->first->show_rights_checkbox) &&
+            filter_var($this->_config->form->first->show_rights_checkbox, FILTER_VALIDATE_BOOLEAN)) {
             $this->showRights = 1;
             $rightsCheckbox = $this->createElement('checkbox', 'rights');
             $rightsCheckbox
-                    ->setDisableTranslator(true)
-                    ->setLabel('rights')
-                    ->setRequired(true)
-                    ->setChecked(false);
+                ->setDisableTranslator(true)
+                ->setLabel('rights')
+                ->setRequired(true)
+                ->setChecked(false);
+        }
+        else {
+            $this->showRights = 0;
+            $rightsCheckbox = null;
         }
 
         return $rightsCheckbox;

--- a/modules/publish/models/Validation.php
+++ b/modules/publish/models/Validation.php
@@ -434,7 +434,8 @@ class Publish_Model_Validation
 
             $config = Zend_Registry::get('Zend_Config');
 
-            if (isset($config->browsing->series->sortByTitle) && boolval($config->browsing->series->sortByTitle)) {
+            if (isset($config->browsing->series->sortByTitle) &&
+                filter_var($config->browsing->series->sortByTitle, FILTER_VALIDATE_BOOLEAN)) {
                 uasort($sets, function ($value1, $value2) {
                     return strnatcmp($value1, $value2);
                 });

--- a/modules/publish/views/helpers/BibliographieOverview.php
+++ b/modules/publish/views/helpers/BibliographieOverview.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -48,7 +47,8 @@ class Publish_View_Helper_BibliographieOverview extends Zend_View_Helper_Abstrac
     public function bibliographieOverview()
     {
         $config = Zend_Registry::get('Zend_Config');
-        if (! isset($config->form->first->bibliographie) || $config->form->first->bibliographie != 1) {
+        if (! isset($config->form->first->bibliographie) ||
+            (! filter_var($config->form->first->bibliographie, FILTER_VALIDATE_BOOLEAN))) {
             return;
         }
 

--- a/modules/publish/views/helpers/FileOverview.php
+++ b/modules/publish/views/helpers/FileOverview.php
@@ -49,7 +49,8 @@ class Publish_View_Helper_FileOverview extends Zend_View_Helper_Abstract
     public function fileOverview()
     {
         $config = Zend_Registry::get('Zend_Config');
-        if (! isset($config->form->first->enable_upload) || $config->form->first->enable_upload != 1) {
+        if (! isset($config->form->first->enable_upload) ||
+            (! filter_var($config->form->first->enable_upload, FILTER_VALIDATE_BOOLEAN))) {
             return;
         }
 

--- a/modules/review/controllers/IndexController.php
+++ b/modules/review/controllers/IndexController.php
@@ -161,13 +161,11 @@ class Review_IndexController extends Application_Controller_Action
         $this->view->documentCount = count($ids);
         $this->view->actionUrl = $this->view->url(['action' => 'clear']);
 
-        $useCurrentUser = false;
         $person = null;
 
         $config = $this->getConfig();
-        if (isset($config, $config->clearing->addCurrentUserAsReferee)) {
-            $useCurrentUser = $config->clearing->addCurrentUserAsReferee;
-        }
+        $useCurrentUser = isset($config, $config->clearing->addCurrentUserAsReferee) &&
+            filter_var($config->clearing->addCurrentUserAsReferee, FILTER_VALIDATE_BOOLEAN);
 
         if ($useCurrentUser) {
             $person = $this->_loggedUser->createPerson();

--- a/modules/solrsearch/models/SeriesUtil.php
+++ b/modules/solrsearch/models/SeriesUtil.php
@@ -77,7 +77,8 @@ class Solrsearch_Model_SeriesUtil extends Application_Model_Abstract
 
         $config = $this->getConfig();
 
-        if (isset($config->browsing->series->sortByTitle) && boolval($config->browsing->series->sortByTitle)) {
+        if (isset($config->browsing->series->sortByTitle) &&
+            filter_var($config->browsing->series->sortByTitle, FILTER_VALIDATE_BOOLEAN)) {
             usort($allSeries, function ($value1, $value2) {
                     return strnatcmp($value1['title'], $value2['title']);
             });

--- a/modules/solrsearch/views/scripts/index/browsecollection.phtml
+++ b/modules/solrsearch/views/scripts/index/browsecollection.phtml
@@ -29,7 +29,6 @@
  * @author      Sascha Szott <szott@zib.de>
  * @copyright   Copyright (c) 2008-2010, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
  */
 ?>
 
@@ -71,7 +70,9 @@
 <h2><?= htmlspecialchars($this->title) ?></h2>
 
 <?php
-    $this->disableEmptyCollections = Zend_Registry::get('Zend_Config')->browsing->disableEmptyCollections;
+    $config = Zend_Registry::get('Zend_Config');
+    $this->disableEmptyCollections = isset($config->browsing->disableEmptyCollections) &&
+        filter_var($config->browsing->disableEmptyCollections, FILTER_VALIDATE_BOOLEAN);
     $collRoleName = htmlspecialchars($this->collectionRole->getName(), ENT_QUOTES);
 ?>
 

--- a/modules/sword/controllers/ServicedocumentController.php
+++ b/modules/sword/controllers/ServicedocumentController.php
@@ -76,8 +76,8 @@ class Sword_ServicedocumentController extends Zend_Rest_Controller
         $domDocument = $serviceDocument->getDocument();
 
         $config = Zend_Registry::get('Zend_Config');
-        $prettyPrinting = $config->prettyXml;
-        if ($prettyPrinting == 'true') {
+        $prettyPrinting = isset($config->prettyXml) && filter_var($config->prettyXml, FILTER_VALIDATE_BOOLEAN);
+        if ($prettyPrinting) {
             $domDocument->preserveWhiteSpace = false;
             $domDocument->formatOutput = true;
         }

--- a/modules/sword/models/AtomEntryDocument.php
+++ b/modules/sword/models/AtomEntryDocument.php
@@ -57,8 +57,8 @@ class Sword_Model_AtomEntryDocument
 
         if (! empty($this->entries)) {
             $config = Zend_Registry::get('Zend_Config');
-            $prettyPrinting = $config->prettyXml;
-            if ($prettyPrinting == 'true') {
+            $prettyPrinting = isset($config->prettyXml) && filter_var($config->prettyXml, FILTER_VALIDATE_BOOLEAN);
+            if ($prettyPrinting) {
                 $dom = new DOMDocument;
                 $dom->preserveWhiteSpace = false;
                 $dom->formatOutput = true;

--- a/public/layouts/default/common.phtml
+++ b/public/layouts/default/common.phtml
@@ -243,7 +243,7 @@ if (isset($config->javascript->latex->mathjax)) {
 
         <?php
             $dbprofiler = Zend_Registry::get('db_adapter')->getProfiler();
-            $profiler_show_queries = (bool) $config->db->params->showqueries;
+            $profiler_show_queries = isset($config->db->params->showqueries) && filter_var($config->db->params->showqueries, FILTER_VALIDATE_BOOLEAN);
             $profiler_max_queries = (int) $config->db->params->maxqueries;
             if ($dbprofiler->getEnabled() === true) :
         ?>

--- a/public/layouts/opus4/debug.phtml
+++ b/public/layouts/opus4/debug.phtml
@@ -1,6 +1,6 @@
 <?php
 $dbprofiler = Zend_Registry::get('db_adapter')->getProfiler();
-$profiler_show_queries = (bool) $config->db->params->showqueries;
+$profiler_show_queries = isset($config->db->params->showqueries) && filter_var($config->db->params->showqueries, FILTER_VALIDATE_BOOLEAN);
 $profiler_max_queries = (int) $config->db->params->maxqueries;
 if ($dbprofiler->getEnabled() === true) :
     ?>

--- a/scripts/SolrFulltextCacheBuilder.php
+++ b/scripts/SolrFulltextCacheBuilder.php
@@ -241,9 +241,9 @@ class SolrFulltextCacheBuilder
     private function forceSyncMode()
     {
         $config = Zend_Registry::get('Zend_Config');
-        if (isset($config->runjobs->asynchronous) && $config->runjobs->asynchronous) {
+        if (isset($config->runjobs->asynchronous) && filter_var($config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
             $this->_syncMode = false;
-            $config->runjobs->asynchronous = 0;
+            $config->runjobs->asynchronous = ''; // false
             Zend_Registry::set('Zend_Config', $config);
         }
     }
@@ -252,7 +252,7 @@ class SolrFulltextCacheBuilder
     {
         if (! $this->_syncMode) {
             $config = Zend_Registry::get('Zend_Config');
-            $config->runjobs->asynchronous = 1;
+            $config->runjobs->asynchronous = '1'; // true
             Zend_Registry::set('Zend_Config', $config);
         }
     }

--- a/scripts/SolrIndexBuilder.php
+++ b/scripts/SolrIndexBuilder.php
@@ -329,9 +329,9 @@ EOT;
     private function forceSyncMode()
     {
         $config = Zend_Registry::get('Zend_Config');
-        if (isset($config->runjobs->asynchronous) && $config->runjobs->asynchronous) {
+        if (isset($config->runjobs->asynchronous) && filter_var($config->runjobs->asynchronous, FILTER_VALIDATE_BOOLEAN)) {
             $this->_syncMode = false;
-            $config->runjobs->asynchronous = 0;
+            $config->runjobs->asynchronous = ''; // false
             Zend_Registry::set('Zend_Config', $config);
         }
     }
@@ -340,7 +340,7 @@ EOT;
     {
         if (! $this->_syncMode) {
             $config = Zend_Registry::get('Zend_Config');
-            $config->runjobs->asynchronous = 1;
+            $config->runjobs->asynchronous = '1'; // true
             Zend_Registry::set('Zend_Config', $config);
         }
     }

--- a/scripts/common/console.php
+++ b/scripts/common/console.php
@@ -37,7 +37,7 @@
  */
 
 $config = Zend_Registry::get('Zend_Config');
-if ($config->security !== '0') {
+if (isset($config->security) && filter_var($config->security, FILTER_VALIDATE_BOOLEAN)) {
     // setup realm
     $realm = Opus_Security_Realm::getInstance();
 }

--- a/tests/library/Application/Form/Element/HitsPerPageTest.php
+++ b/tests/library/Application/Form/Element/HitsPerPageTest.php
@@ -61,7 +61,7 @@ class Application_Form_Element_HitsPerPageTest extends ControllerTestCase
     public function testInitWithCustomDefaultRows()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => 15]]
+            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => '15']]
         ]));
 
         $element = new Application_Form_Element_HitsPerPage('rows');

--- a/tests/library/Application/Security/AccessTest.php
+++ b/tests/library/Application/Security/AccessTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -51,7 +50,6 @@ class Application_Security_AccessTest extends ControllerTestCase
         $this->dispatch('/admin');
 
         $this->logoutUser();
-        $this->restoreSecuritySetting();
 
         $this->assertQuery('//a[@href="/admin/licence"]');
         $this->assertQuery('//a[@href="/admin/index/info"]');

--- a/tests/library/Application/TranslateTest.php
+++ b/tests/library/Application/TranslateTest.php
@@ -133,10 +133,8 @@ class Application_TranslateTest extends ControllerTestCase
     public function testIsLogUntranslatedEnabledTrue()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $logUntranslated = $config->log->untranslated;
         $config->log->untranslated = '1';
         $this->assertTrue($this->translate->isLogUntranslatedEnabled());
-        $config->log->untranslated = $logUntranslated;
     }
 
     public function testIsLogUntranslatedEnabledFalse()
@@ -150,7 +148,6 @@ class Application_TranslateTest extends ControllerTestCase
     public function testGetOptionsLogEnabled()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $logUntranslated = $config->log->untranslated;
         $config->log->untranslated = '1';
 
         $options = $this->translate->getOptions();
@@ -160,14 +157,11 @@ class Application_TranslateTest extends ControllerTestCase
         $this->assertArrayHasKey('log', $options);
         $this->assertInstanceOf('Zend_Log', $options['log']);
         $this->assertTrue($options['logUntranslated']);
-
-        $config->log->untranslated = $logUntranslated;
     }
 
     public function testGetOptionsLogDisabled()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $logUntranslated = $config->log->untranslated;
         $config->log->untranslated = '';
 
         $options = $this->translate->getOptions();
@@ -175,14 +169,11 @@ class Application_TranslateTest extends ControllerTestCase
         $this->assertInternalType('array', $options);
         $this->assertEquals(10, count($options));
         $this->assertFalse($options['logUntranslated']);
-
-        $config->log->untranslated = $logUntranslated;
     }
 
     public function testLoggingEnabled()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $logUntranslated = $config->log->untranslated;
         $config->log->untranslated = '1';
 
         $logger = new MockLogger();
@@ -196,14 +187,11 @@ class Application_TranslateTest extends ControllerTestCase
         $messages = $logger->getMessages();
         $this->assertEquals(1, count($messages));
         $this->assertContains('Unable to translate', $messages[0]);
-
-        $config->log->untranslated = $logUntranslated;
     }
 
     public function testLoggingDisabled()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $logUntranslated = $config->log->untranslated;
         $config->log->untranslated = '';
 
         $logger = new MockLogger();
@@ -216,8 +204,6 @@ class Application_TranslateTest extends ControllerTestCase
 
         $messages = $logger->getMessages();
         $this->assertEquals(0, count($messages));
-
-        $config->log->untranslated = $logUntranslated;
     }
 
     public function enLanguageDataProvider()

--- a/tests/library/Application/TranslateTest.php
+++ b/tests/library/Application/TranslateTest.php
@@ -134,7 +134,7 @@ class Application_TranslateTest extends ControllerTestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         $logUntranslated = $config->log->untranslated;
-        $config->log->untranslated = true;
+        $config->log->untranslated = '1';
         $this->assertTrue($this->translate->isLogUntranslatedEnabled());
         $config->log->untranslated = $logUntranslated;
     }
@@ -142,7 +142,7 @@ class Application_TranslateTest extends ControllerTestCase
     public function testIsLogUntranslatedEnabledFalse()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->log->untranslated = false;
+        $config->log->untranslated = '';
         $this->assertFalse($this->translate->isLogUntranslatedEnabled());
         $config->log->untranslated = true; // Siehe testIsLogUntranslatedEnabledTrue
     }
@@ -151,7 +151,7 @@ class Application_TranslateTest extends ControllerTestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         $logUntranslated = $config->log->untranslated;
-        $config->log->untranslated = true;
+        $config->log->untranslated = '1';
 
         $options = $this->translate->getOptions();
 
@@ -168,7 +168,7 @@ class Application_TranslateTest extends ControllerTestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         $logUntranslated = $config->log->untranslated;
-        $config->log->untranslated = false;
+        $config->log->untranslated = '';
 
         $options = $this->translate->getOptions();
 
@@ -183,7 +183,7 @@ class Application_TranslateTest extends ControllerTestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         $logUntranslated = $config->log->untranslated;
-        $config->log->untranslated = true;
+        $config->log->untranslated = '1';
 
         $logger = new MockLogger();
 
@@ -204,7 +204,7 @@ class Application_TranslateTest extends ControllerTestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         $logUntranslated = $config->log->untranslated;
-        $config->log->untranslated = false;
+        $config->log->untranslated = '';
 
         $logger = new MockLogger();
 

--- a/tests/library/Application/TranslateTest.php
+++ b/tests/library/Application/TranslateTest.php
@@ -142,7 +142,6 @@ class Application_TranslateTest extends ControllerTestCase
         $config = Zend_Registry::get('Zend_Config');
         $config->log->untranslated = '';
         $this->assertFalse($this->translate->isLogUntranslatedEnabled());
-        $config->log->untranslated = true; // Siehe testIsLogUntranslatedEnabledTrue
     }
 
     public function testGetOptionsLogEnabled()

--- a/tests/library/Application/Util/NotificationTest.php
+++ b/tests/library/Application/Util/NotificationTest.php
@@ -34,7 +34,6 @@
 
 class Application_Util_NotificationTest extends ControllerTestCase
 {
-
     protected $configModifiable = true;
 
     protected $additionalResources = 'database';
@@ -52,8 +51,8 @@ class Application_Util_NotificationTest extends ControllerTestCase
         $this->logger = Zend_Registry::get('Zend_Log');
         // add required config keys
         $this->config = Zend_Registry::get('Zend_Config');
-        $this->config->notification->document->submitted->enabled = 1;
-        $this->config->notification->document->published->enabled = 1;
+        $this->config->notification->document->submitted->enabled = '1';
+        $this->config->notification->document->published->enabled = '1';
         $this->config->notification->document->submitted->subject = 'Dokument #%1$s eingestellt: %2$s : %3$s';
         $this->config->notification->document->published->subject = 'Dokument #%1$s veröffentlicht: %2$s : %3$s';
         $this->config->notification->document->submitted->template = 'submitted.phtml';
@@ -242,7 +241,7 @@ class Application_Util_NotificationTest extends ControllerTestCase
             }
         }
 
-        $this->config->merge(new Zend_Config(['runjobs' => ['asynchronous' => 1]]));
+        $this->config->merge(new Zend_Config(['runjobs' => ['asynchronous' => '1']]));
         $this->assertEquals(0, Opus_Job::getCount(), 'test data changed.');
 
         $doc = $this->createTestDocument();

--- a/tests/library/Application/Util/PublicationNotificationTest.php
+++ b/tests/library/Application/Util/PublicationNotificationTest.php
@@ -51,8 +51,8 @@ class Application_Util_PublicationNotificationTest extends ControllerTestCase
         $this->logger = Zend_Registry::get('Zend_Log');
         // add required config keys
         $this->config = Zend_Registry::get('Zend_Config');
-        $this->config->notification->document->submitted->enabled = 1;
-        $this->config->notification->document->published->enabled = 1;
+        $this->config->notification->document->submitted->enabled = '1';
+        $this->config->notification->document->published->enabled = '1';
         $this->config->notification->document->submitted->subject = 'Dokument #%1$s eingestellt: %2$s : %3$s';
         $this->config->notification->document->published->subject = 'Dokument #%1$s veröffentlicht: %2$s : %3$s';
         $this->config->notification->document->submitted->template = 'submitted.phtml';

--- a/tests/library/Application/View/Helper/CustomFileSortingEnabledTest.php
+++ b/tests/library/Application/View/Helper/CustomFileSortingEnabledTest.php
@@ -33,7 +33,6 @@
 
 class Application_View_Helper_CustomFileSortingEnabledTest extends ControllerTestCase
 {
-
     protected $configModifiable = true;
 
     public function testCustomFileSortingEnabled()
@@ -43,7 +42,7 @@ class Application_View_Helper_CustomFileSortingEnabledTest extends ControllerTes
         $this->assertTrue($helper->customFileSortingEnabled());
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'frontdoor' => ['files' => ['customSorting' => '0']]
+            'frontdoor' => ['files' => ['customSorting' => '']]
         ]));
 
         $this->assertFalse($helper->customFileSortingEnabled());

--- a/tests/library/Application/View/Helper/OptionEnabledTest.php
+++ b/tests/library/Application/View/Helper/OptionEnabledTest.php
@@ -44,7 +44,7 @@ class Application_View_Helper_OptionEnabledTest extends ControllerTestCase
         $this->assertTrue($helper->optionEnabled('linkAuthor.frontdoor', 'orcid'));
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'orcid' => ['linkAuthor' => ['frontdoor' => '0']]
+            'orcid' => ['linkAuthor' => ['frontdoor' => '']]
         ]));
 
         $this->assertFalse($helper->optionEnabled('orcid.linkAuthor.frontdoor'));

--- a/tests/library/Application/View/Helper/ShortenTextTest.php
+++ b/tests/library/Application/View/Helper/ShortenTextTest.php
@@ -45,7 +45,7 @@ class Application_View_Helper_ShortenTextTest extends ControllerTestCase
         $helper = new Application_View_Helper_ShortenText();
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'frontdoor' => ['numOfShortAbstractChars' => 10]
+            'frontdoor' => ['numOfShortAbstractChars' => '10']
         ]));
 
         $this->assertEquals('short text', $helper->shortenText('short text'));
@@ -71,7 +71,7 @@ class Application_View_Helper_ShortenTextTest extends ControllerTestCase
         $helper = new Application_View_Helper_ShortenText();
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'frontdoor' => ['numOfShortAbstractChars' => 10]
+            'frontdoor' => ['numOfShortAbstractChars' => '10']
         ]));
 
         $this->assertEquals(10, $helper->getMaxLength());
@@ -90,7 +90,7 @@ class Application_View_Helper_ShortenTextTest extends ControllerTestCase
         $helper = new Application_View_Helper_ShortenText();
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'frontdoor' => ['numOfShortAbstractChars' => 10]
+            'frontdoor' => ['numOfShortAbstractChars' => '10']
         ]));
 
         $this->assertEquals(10, $helper->getMaxLength());

--- a/tests/modules/account/controllers/IndexControllerTest.php
+++ b/tests/modules/account/controllers/IndexControllerTest.php
@@ -74,7 +74,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testIndexSuccessAction()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 1;
+        $config->account->editOwnAccount = '1';
 
         $this->loginUser('admin', 'adminadmin');
         $this->dispatch('/account');
@@ -90,7 +90,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testIndexDeniedIfEditAccountDisabledAction()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 0;
+        $config->account->editOwnAccount = ''; // false
 
         $this->loginUser('admin', 'adminadmin');
         $this->dispatch('/account');
@@ -110,7 +110,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testChangePasswordFailsOnMissingInputAction()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 1;
+        $config->account->editOwnAccount = '1';
 
         $this->loginUser('john', 'testpwd');
         $this->request
@@ -135,7 +135,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testChangePasswordFailsOnNoMatch()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 1;
+        $config->account->editOwnAccount = '1';
 
         $this->loginUser('john', 'testpwd');
         $this->request
@@ -164,7 +164,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testChangePasswordSuccess()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 1;
+        $config->account->editOwnAccount = '1';
 
         $this->loginUser('john', 'testpwd');
         $this->request
@@ -193,7 +193,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testChangePasswordSuccessWithSpecialChars()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 1;
+        $config->account->editOwnAccount = '1';
 
         $this->loginUser('john', 'testpwd');
         $this->request
@@ -222,7 +222,7 @@ class Account_IndexControllerTest extends ControllerTestCase
     public function testChangeLoginSuccess()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->account->editOwnAccount = 1;
+        $config->account->editOwnAccount = '1';
 
         $this->deleteUser('john2');
 

--- a/tests/modules/admin/controllers/AccountControllerTest.php
+++ b/tests/modules/admin/controllers/AccountControllerTest.php
@@ -368,7 +368,6 @@ class Admin_AccountControllerTest extends ControllerTestCase
         $this->dispatch('/admin/account');
         $this->assertResponseCode(200, $this->getResponse()->getBody());
         $this->logoutUser();
-        $this->restoreSecuritySetting();
 
         $user = new Opus_Account(null, null, 'security4');
 

--- a/tests/modules/admin/controllers/DocumentsControllerTest.php
+++ b/tests/modules/admin/controllers/DocumentsControllerTest.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry
@@ -37,7 +37,6 @@
  */
 class Admin_DocumentsControllerTest extends ControllerTestCase
 {
-
     protected $additionalResources = ['database', 'view', 'mainMenu', 'navigation', 'translation'];
 
     /**
@@ -165,7 +164,7 @@ class Admin_DocumentsControllerTest extends ControllerTestCase
     public function testConfigureDefaultHitsPerPage()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->admin->documents->maxDocsDefault = 7;
+        $config->admin->documents->maxDocsDefault = '7';
 
         $this->dispatch('/admin/documents');
         $this->assertQueryCount('span.title', 7);

--- a/tests/modules/admin/controllers/IndexmaintenanceControllerTest.php
+++ b/tests/modules/admin/controllers/IndexmaintenanceControllerTest.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry
@@ -168,12 +168,12 @@ class Admin_IndexmaintenanceControllerTest extends ControllerTestCase
 
     private function enableAsyncMode()
     {
-        $this->setAsyncMode(1);
+        $this->setAsyncMode('1');
     }
 
     private function disableAsyncMode()
     {
-        $this->setAsyncMode(0);
+        $this->setAsyncMode('');
     }
 
     private function setAsyncMode($value)
@@ -190,12 +190,12 @@ class Admin_IndexmaintenanceControllerTest extends ControllerTestCase
 
     private function enableAsyncIndexmaintenanceMode()
     {
-        $this->setAsyncIndexmaintenanceMode(1);
+        $this->setAsyncIndexmaintenanceMode('1');
     }
 
     private function disableAsyncIndexmaintenanceMode()
     {
-        $this->setAsyncIndexmaintenanceMode(0);
+        $this->setAsyncIndexmaintenanceMode('');
     }
 
     private function setAsyncIndexmaintenanceMode($value)

--- a/tests/modules/admin/controllers/IndexmaintenanceControllerTest.php
+++ b/tests/modules/admin/controllers/IndexmaintenanceControllerTest.php
@@ -173,7 +173,7 @@ class Admin_IndexmaintenanceControllerTest extends ControllerTestCase
 
     private function disableAsyncMode()
     {
-        $this->setAsyncMode('');
+        $this->setAsyncMode(''); // false
     }
 
     private function setAsyncMode($value)
@@ -195,7 +195,7 @@ class Admin_IndexmaintenanceControllerTest extends ControllerTestCase
 
     private function disableAsyncIndexmaintenanceMode()
     {
-        $this->setAsyncIndexmaintenanceMode('');
+        $this->setAsyncIndexmaintenanceMode(''); // false
     }
 
     private function setAsyncIndexmaintenanceMode($value)

--- a/tests/modules/admin/controllers/JobControllerTest.php
+++ b/tests/modules/admin/controllers/JobControllerTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -49,7 +48,7 @@ class Admin_JobControllerTest extends ControllerTestCase
 
         $config = Zend_Registry::get('Zend_Config');
         $this->__configBackup = $config;
-        $config->merge(new Zend_Config(['runjobs' => ['asynchronous' => true]]));
+        $config->merge(new Zend_Config(['runjobs' => ['asynchronous' => '1']]));
 
         $this->assertEquals(0, Opus_Job::getCount(Opus_Job::STATE_FAILED), 'test data changed.');
 

--- a/tests/modules/admin/controllers/LanguageControllerTest.php
+++ b/tests/modules/admin/controllers/LanguageControllerTest.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry

--- a/tests/modules/admin/controllers/WorkflowControllerTest.php
+++ b/tests/modules/admin/controllers/WorkflowControllerTest.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry
@@ -44,7 +44,7 @@ class Admin_WorkflowControllerTest extends ControllerTestCase
     private function enablePublishNotification()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->notification->document->published->enabled = 1;
+        $config->notification->document->published->enabled = '1';
         $config->notification->document->published->email = "published@localhost";
     }
 
@@ -433,7 +433,7 @@ class Admin_WorkflowControllerTest extends ControllerTestCase
     public function testConfirmationDisabled()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'confirmation' => ['document' => ['statechange' => ['enabled' => '0']]]
+            'confirmation' => ['document' => ['statechange' => ['enabled' => '']]]
         ]));
 
         $this->dispatch('/admin/workflow/changestate/docId/102/targetState/deleted');

--- a/tests/modules/admin/controllers/WorkflowControllerTest.php
+++ b/tests/modules/admin/controllers/WorkflowControllerTest.php
@@ -433,7 +433,7 @@ class Admin_WorkflowControllerTest extends ControllerTestCase
     public function testConfirmationDisabled()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'confirmation' => ['document' => ['statechange' => ['enabled' => '']]]
+            'confirmation' => ['document' => ['statechange' => ['enabled' => '']]] // false
         ]));
 
         $this->dispatch('/admin/workflow/changestate/docId/102/targetState/deleted');

--- a/tests/modules/admin/models/IndexMaintenanceTest.php
+++ b/tests/modules/admin/models/IndexMaintenanceTest.php
@@ -105,9 +105,9 @@ class Admin_Model_IndexMaintenanceTest extends ControllerTestCase
 
         $config = Zend_Registry::get('Zend_Config');
         if (isset($config->runjobs->asynchronous)) {
-            $config->runjobs->asynchronous = 1;
+            $config->runjobs->asynchronous = '1';
         } else {
-            $config = new Zend_Config(['runjobs' => ['asynchronous' => 1]], true);
+            $config = new Zend_Config(['runjobs' => ['asynchronous' => '1']], true);
             $config->merge(Zend_Registry::get('Zend_Config'));
         }
         Zend_Registry::set('Zend_Config', $config);
@@ -119,9 +119,9 @@ class Admin_Model_IndexMaintenanceTest extends ControllerTestCase
 
         $config = Zend_Registry::get('Zend_Config');
         if (isset($config->runjobs->indexmaintenance->asynchronous)) {
-            $config->runjobs->indexmaintenance->asynchronous = 1;
+            $config->runjobs->indexmaintenance->asynchronous = '1';
         } else {
-            $config = new Zend_Config(['runjobs' => ['indexmaintenance' => ['asynchronous' => 1]]], true);
+            $config = new Zend_Config(['runjobs' => ['indexmaintenance' => ['asynchronous' => '1']]], true);
             $config->merge(Zend_Registry::get('Zend_Config'));
         }
 

--- a/tests/modules/export/BibtexExportTest.php
+++ b/tests/modules/export/BibtexExportTest.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry
@@ -27,7 +27,7 @@
  * @category    Tests
  * @package     Export
  * @author      Jens Schwidder <schwidder@zib.de>
- * @copyright   Copyright (c) 2017, OPUS 4 development team
+ * @copyright   Copyright (c) 2017-2019, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 
@@ -43,7 +43,7 @@ class Export_BibtexExportTest extends ControllerTestCase
         parent::setUp();
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => 10]]
+            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => '10']]
         ]));
     }
 
@@ -78,7 +78,7 @@ class Export_BibtexExportTest extends ControllerTestCase
     public function testExportSingleDocument()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'export' => ['download' => '0']
+            'export' => ['download' => ''] // false
         ]));
 
         $this->dispatch('/export/index/bibtex/searchtype/id/docId/146');
@@ -97,8 +97,8 @@ class Export_BibtexExportTest extends ControllerTestCase
     public function testExportLatestDocuments()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'export' => ['download' => '0'],
-            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => 10]]
+            'export' => ['download' => ''], // false
+            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => '10']]
         ]));
 
         $this->dispatch('/export/index/bibtex/searchtype/latest');
@@ -113,7 +113,7 @@ class Export_BibtexExportTest extends ControllerTestCase
     public function testExportLatestDocumentsWithCustomRows()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'export' => ['download' => '0']
+            'export' => ['download' => ''] // false
         ]));
 
         $this->dispatch('/export/index/bibtex/searchtype/latest/rows/12');

--- a/tests/modules/export/controllers/IndexControllerTest.php
+++ b/tests/modules/export/controllers/IndexControllerTest.php
@@ -722,6 +722,7 @@ class Export_IndexControllerTest extends ControllerTestCase
     public function testPublistActionGroupedByCompletedYear()
     {
         $config = Zend_Registry::get('Zend_Config');
+        // FIXME OPUSVIER-4130 config does not make sense - completely ignores value of setting
         if (isset($config->plugins->export->publist->groupby->completedyear)) {
             $config->plugins->export->publist->groupby->completedyear = '1';
         } else {

--- a/tests/modules/export/controllers/IndexControllerTest.php
+++ b/tests/modules/export/controllers/IndexControllerTest.php
@@ -195,14 +195,10 @@ class Export_IndexControllerTest extends ControllerTestCase
 
         // enable security
         $config = Zend_Registry::get('Zend_Config');
-        $security = $config->security;
         $config->security = '1';
         Zend_Registry::set('Zend_Config', $config);
 
         $this->dispatch('/export/index/index/export/xml');
-
-        $config->security = $security;
-        Zend_Registry::set('Zend_Config', $config);
 
         $this->assertResponseCode(500);
         $this->assertContains('missing parameter stylesheet', $this->getResponse()->getBody());
@@ -231,21 +227,13 @@ class Export_IndexControllerTest extends ControllerTestCase
         $config = Zend_Registry::get('Zend_Config');
         $host = $config->searchengine->index->host;
         $port = $config->searchengine->index->port;
-        $oldValue = $config->searchengine->index->app;
         $this->disableSolr();
 
-        $security = $config->security;
         $config->security = '1';
         Zend_Registry::set('Zend_Config', $config);
 
         $this->dispatch('/export/index/index/searchtype/all/export/xml/stylesheet/example');
         $body = $this->getResponse()->getBody();
-
-        // restore configuration
-        $config = Zend_Registry::get('Zend_Config');
-        $config->searchengine->index->app = $oldValue;
-        $config->security = $security;
-        Zend_Registry::set('Zend_Config', $config);
 
         $this->assertNotContains("http://${host}:${port}/solr/corethatdoesnotexist", $body);
         $this->assertContains("exception 'Application_SearchException' with message 'search server is not responding -- try again later'", $body);
@@ -632,9 +620,6 @@ class Export_IndexControllerTest extends ControllerTestCase
 
     public function testPublistActionWithoutStylesheetParameterInUrlAndInvalidConfigParameter()
     {
-        // manipulate application configuration
-        $oldConfig = Zend_Registry::get('Zend_Config');
-
         $config = Zend_Registry::get('Zend_Config');
         if (isset($config->plugins->export->publist->stylesheet)) {
             $config->plugins->export->publist->stylesheet = 'invalid';
@@ -648,8 +633,6 @@ class Export_IndexControllerTest extends ControllerTestCase
 
         $this->dispatch('/export/index/publist/role/publists/number/coll_visible');
 
-        // undo configuration manipulation
-        Zend_Registry::set('Zend_Config', $oldConfig);
         $this->assertResponseCode(500);
         $response = $this->getResponse();
         $this->assertContains('given stylesheet does not exist or is not readable', $response->getBody());
@@ -657,9 +640,6 @@ class Export_IndexControllerTest extends ControllerTestCase
 
     public function testPublistActionWithValidStylesheetInConfig()
     {
-        // manipulate application configuration
-        $oldConfig = Zend_Registry::get('Zend_Config');
-
         $config = Zend_Registry::get('Zend_Config');
         if (isset($config->plugins->export->publist->stylesheet)) {
             $config->plugins->export->publist->stylesheet = 'raw';
@@ -682,8 +662,6 @@ class Export_IndexControllerTest extends ControllerTestCase
 
         $this->dispatch('/export/index/publist/role/publists/number/coll_visible');
 
-        // undo configuration manipulation
-        Zend_Registry::set('Zend_Config', $oldConfig);
         $this->assertResponseCode(200);
         $response = $this->getResponse();
         $this->assertContains('<export timestamp=', $response->getBody());
@@ -1012,8 +990,6 @@ class Export_IndexControllerTest extends ControllerTestCase
      */
     public function testNonAdminAccessOnUnrestrictedMarc21ExportAllowed()
     {
-        $config = Zend_Registry::get('Zend_Config');
-
         Zend_Registry::get('Zend_Config')->merge(
             new Zend_Config(
                 ['plugins' => ['export' => ['marc21' => ['adminOnly' => '']]]]
@@ -1028,9 +1004,6 @@ class Export_IndexControllerTest extends ControllerTestCase
         if ($exportAccessProvided) {
             $this->removeAccessOnModuleExportForGuest();
         }
-
-        // revert configuration changes
-        Zend_Registry::set('Zend_Config', $config);
 
         $this->assertResponseCode(200);
     }

--- a/tests/modules/export/models/XmlExportTest.php
+++ b/tests/modules/export/models/XmlExportTest.php
@@ -57,8 +57,8 @@ class Export_Model_XmlExportTest extends ControllerTestCase
         $plugin->init();
         $plugin->setConfig(new Zend_Config([
             'class' => 'Export_Model_XmlExport',
-            'maxDocumentsGuest' => 100,
-            'maxDocumentsUser' => 500,
+            'maxDocumentsGuest' => '100',
+            'maxDocumentsUser' => '500',
         ]));
 
         $this->plugin = $plugin;
@@ -267,7 +267,7 @@ class Export_Model_XmlExportTest extends ControllerTestCase
         $plugin->setDownloadEnabled(null);
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'export' => ['download' => '0']
+            'export' => ['download' => '']
         ]));
 
         $this->assertFalse($plugin->isDownloadEnabled());

--- a/tests/modules/frontdoor/controllers/IndexControllerTest.php
+++ b/tests/modules/frontdoor/controllers/IndexControllerTest.php
@@ -790,7 +790,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     {
         // Aktiviere Kürzung von Abstrakten
         $config = Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
-            ['frontdoor' => ['numOfShortAbstractChars' => 200]]
+            ['frontdoor' => ['numOfShortAbstractChars' => '200']]
         ));
 
         $this->dispatch('/frontdoor/index/index/docId/92');
@@ -932,7 +932,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testFilesInCustomSortOrder()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->frontdoor->files->customSorting = 1;
+        $config->frontdoor->files->customSorting = '1';
 
         $this->dispatch('/frontdoor/index/index/docId/155');
 
@@ -951,7 +951,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testFilesInAlphabeticSortOrder()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->frontdoor->files->customSorting = 0;
+        $config->frontdoor->files->customSorting = '';
 
         $this->dispatch('/frontdoor/index/index/docId/155');
 
@@ -1362,7 +1362,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testGoogleScholarOpenInNewWindowEnabled()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'googleScholar' => ['openInNewWindow' => 1]
+            'googleScholar' => ['openInNewWindow' => '1']
         ]));
         $this->dispatch('/frontdoor/index/index/docId/146');
         $this->assertResponseCode(200);
@@ -1373,7 +1373,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testGoogleScholarOpenInNewWindowDisabled()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'googleScholar' => ['openInNewWindow' => 0]
+            'googleScholar' => ['openInNewWindow' => '']
         ]));
         $this->dispatch('/frontdoor/index/index/docId/146');
         $this->assertResponseCode(200);
@@ -1395,7 +1395,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testTwitterOpenInNewWindowEnabled()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'twitter' => ['openInNewWindow' => 1]
+            'twitter' => ['openInNewWindow' => '1']
         ]));
         $this->dispatch('/frontdoor/index/index/docId/146');
         $this->assertResponseCode(200);
@@ -1406,7 +1406,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testTwitterOpenInNewWindowDisabled()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'twitter' => ['openInNewWindow' => 0]
+            'twitter' => ['openInNewWindow' => '']
         ]));
         $this->dispatch('/frontdoor/index/index/docId/146');
         $this->assertResponseCode(200);
@@ -1455,7 +1455,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     {
         $this->useEnglish();
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'frontdoor' => ['metadata' => ['BelongsToBibliography' => 1]]
+            'frontdoor' => ['metadata' => ['BelongsToBibliography' => '1']]
         ]));
 
         $this->dispatch('/frontdoor/index/index/docId/146');
@@ -1467,7 +1467,7 @@ class Frontdoor_IndexControllerTest extends ControllerTestCase
     public function testBelongsToBibliographyTurnedOff()
     {
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'frontdoor' => ['metadata' => ['BelongsToBibliography' => 0]]
+            'frontdoor' => ['metadata' => ['BelongsToBibliography' => '']]
         ]));
 
         $this->dispatch('/frontdoor/index/index/docId/146');

--- a/tests/modules/home/controllers/IndexControllerTest.php
+++ b/tests/modules/home/controllers/IndexControllerTest.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry
@@ -83,7 +83,7 @@ class Home_IndexControllerTest extends ControllerTestCase
     public function testHelpActionSeparate()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->help->separate = true;
+        $config->help->separate = '1';
         $this->dispatch('/home/index/help');
         $this->assertResponseCode(200);
         $this->assertModule('home');

--- a/tests/modules/oai/controllers/ContainerControllerTest.php
+++ b/tests/modules/oai/controllers/ContainerControllerTest.php
@@ -84,7 +84,6 @@ class Oai_ContainerControllerTest extends ControllerTestCase
 
         // enable security
         $config = Zend_Registry::get('Zend_Config');
-        $security = $config->security;
         $config->security = '1';
         Zend_Registry::set('Zend_Config', $config);
 
@@ -97,10 +96,6 @@ class Oai_ContainerControllerTest extends ControllerTestCase
             $r->removeAccessModule('oai');
             $r->store();
         }
-
-        // restore security settings
-        $config->security = $security;
-        Zend_Registry::set('Zend_Config', $config);
 
         $this->assertResponseCode(500);
         $this->assertContains('access to requested document is forbidden', $this->getResponse()->getBody());

--- a/tests/modules/oai/controllers/IndexControllerTest.php
+++ b/tests/modules/oai/controllers/IndexControllerTest.php
@@ -1861,7 +1861,8 @@ class Oai_IndexControllerTest extends ControllerTestCase
         $max_records = '2';
 
         Zend_Registry::get('Zend_Config')->merge(
-            new Zend_Config(['oai' => ['max' => ['listrecords' => $max_records]]]));
+            new Zend_Config(['oai' => ['max' => ['listrecords' => $max_records]]])
+        );
 
         // first request: fetch documents list and expect resumption code
         $this->dispatch("/oai?verb=ListRecords&metadataPrefix=oai_dc");
@@ -1906,7 +1907,8 @@ class Oai_IndexControllerTest extends ControllerTestCase
         $max_records = '100';
 
         Zend_Registry::get('Zend_Config')->merge(
-            new Zend_Config(['oai' => ['max' => ['listrecords' => $max_records]]]));
+            new Zend_Config(['oai' => ['max' => ['listrecords' => $max_records]]])
+        );
 
         // first request: fetch documents list and expect resumption code
         $this->dispatch("/oai?verb=ListRecords&metadataPrefix=oai_dc");

--- a/tests/modules/oai/controllers/IndexControllerTest.php
+++ b/tests/modules/oai/controllers/IndexControllerTest.php
@@ -1288,7 +1288,6 @@ class Oai_IndexControllerTest extends ControllerTestCase
     {
         $this->enableSecurity();
         $this->dispatch('/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai::123');
-        $this->resetSecurity();
 
         $this->assertEquals(200, $this->getResponse()->getHttpResponseCode());
         $this->assertContains('<GetRecord>', $this->getResponse()->getBody());
@@ -1420,7 +1419,6 @@ class Oai_IndexControllerTest extends ControllerTestCase
             $this->getResponse()->getBody(),
             'do not prevent usage of metadataPrefix copy_xml and verb GetRecords'
         );
-        $this->resetSecurity();
     }
 
     /**
@@ -1435,7 +1433,6 @@ class Oai_IndexControllerTest extends ControllerTestCase
             $this->getResponse()->getBody(),
             'do not prevent usage of metadataPrefix copy_xml and verb ListRecords'
         );
-        $this->resetSecurity();
     }
 
     /**
@@ -1450,7 +1447,6 @@ class Oai_IndexControllerTest extends ControllerTestCase
             $this->getResponse()->getBody(),
             'do not prevent usage of metadataPrefix copy_xml and verb ListIdentifiers'
         );
-        $this->resetSecurity();
     }
 
     public function enableSecurity()
@@ -1465,25 +1461,7 @@ class Oai_IndexControllerTest extends ControllerTestCase
         }
 
         // enable security
-        $config = Zend_Registry::get('Zend_Config');
-        $this->_security = $config->security;
-        $config->security = '1';
-        Zend_Registry::set('Zend_Config', $config);
-    }
-
-    private function resetSecurity()
-    {
-        $r = Opus_UserRole::fetchByName('guest');
-
-        if ($this->_addOaiModuleAccess) {
-            $r->removeAccessModule('oai');
-            $r->store();
-        }
-
-        // restore security settings
-        $config = Zend_Registry::get('Zend_Config');
-        $config->security = $this->_security;
-        Zend_Registry::set('Zend_Config', $config);
+        Zend_Registry::get('Zend_Config')->merge(new Zend_Config(['security' => '1']));
     }
 
     /**
@@ -1882,8 +1860,8 @@ class Oai_IndexControllerTest extends ControllerTestCase
     {
         $max_records = '2';
 
-        $config = Zend_Registry::get('Zend_Config');
-        $config->oai->max->listrecords = $max_records;
+        Zend_Registry::get('Zend_Config')->merge(
+            new Zend_Config(['oai' => ['max' => ['listrecords' => $max_records]]]));
 
         // first request: fetch documents list and expect resumption code
         $this->dispatch("/oai?verb=ListRecords&metadataPrefix=oai_dc");
@@ -1927,8 +1905,8 @@ class Oai_IndexControllerTest extends ControllerTestCase
     {
         $max_records = '100';
 
-        $config = Zend_Registry::get('Zend_Config');
-        $config->oai->max->listrecords = $max_records;
+        Zend_Registry::get('Zend_Config')->merge(
+            new Zend_Config(['oai' => ['max' => ['listrecords' => $max_records]]]));
 
         // first request: fetch documents list and expect resumption code
         $this->dispatch("/oai?verb=ListRecords&metadataPrefix=oai_dc");
@@ -2543,9 +2521,6 @@ class Oai_IndexControllerTest extends ControllerTestCase
 
     public function testGetRecordMarc21OfDocId91()
     {
-        // manipulate configuration
-        $config = Zend_Registry::get('Zend_Config');
-
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
             'marc21' => [
                 'isil' => 'DE-9999',
@@ -2555,9 +2530,6 @@ class Oai_IndexControllerTest extends ControllerTestCase
         ]));
 
         $this->dispatch('/oai?verb=GetRecord&metadataPrefix=marc21&identifier=oai::91');
-
-        // revert changes in configuration
-        Zend_Registry::set('Zend_Config', $config);
 
         $this->assertResponseCode(200);
 

--- a/tests/modules/oai/controllers/IndexControllerTest.php
+++ b/tests/modules/oai/controllers/IndexControllerTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -1211,8 +1210,8 @@ class Oai_IndexControllerTest extends ControllerTestCase
             new Zend_Config([
                 'oai' => [
                     'max' => [
-                        'listrecords' => 100,
-                        'listidentifiers' => 200,
+                        'listrecords' => '100',
+                        'listidentifiers' => '200',
                     ]
                 ]
             ])
@@ -1881,7 +1880,7 @@ class Oai_IndexControllerTest extends ControllerTestCase
      */
     public function testListRecordsWithResumptionToken()
     {
-        $max_records = 2;
+        $max_records = '2';
 
         $config = Zend_Registry::get('Zend_Config');
         $config->oai->max->listrecords = $max_records;
@@ -1926,7 +1925,7 @@ class Oai_IndexControllerTest extends ControllerTestCase
      */
     public function testListRecordsWithEmptyResumptionTokenForLastBlock()
     {
-        $max_records = 100;
+        $max_records = '100';
 
         $config = Zend_Registry::get('Zend_Config');
         $config->oai->max->listrecords = $max_records;

--- a/tests/modules/oai/models/ContainerTest.php
+++ b/tests/modules/oai/models/ContainerTest.php
@@ -111,7 +111,6 @@ class Oai_Model_ContainerTest extends ControllerTestCase
 
         // enable security
         $config = Zend_Registry::get('Zend_Config');
-        $security = $config->security;
         $config->security = '1';
         Zend_Registry::set('Zend_Config', $config);
 
@@ -132,10 +131,6 @@ class Oai_Model_ContainerTest extends ControllerTestCase
             $r->removeAccessModule('oai');
             $r->store();
         }
-
-        // restore security settings
-        $config->security = $security;
-        Zend_Registry::set('Zend_Config', $config);
     }
 
     public function testConstructorWithPublishedDocumentWithoutAnyFiles()

--- a/tests/modules/publish/controllers/FormControllerTest.php
+++ b/tests/modules/publish/controllers/FormControllerTest.php
@@ -468,10 +468,6 @@ class Publish_FormControllerTest extends ControllerTestCase
     private function fileNoticeOnThirdFormPage($value)
     {
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->enable_upload)) {
-            $oldval = $config->form->first->enable_upload;
-        }
         $config->form->first->enable_upload = $value;
 
         $doc = $this->createTemporaryDoc();
@@ -491,22 +487,11 @@ class Publish_FormControllerTest extends ControllerTestCase
             ]);
 
         $this->dispatch('/publish/form/check');
-
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->enable_upload);
-        } else {
-            $config->form->first->enable_upload = $oldval;
-        }
     }
 
     private function fileNoticeOnSecondFormPage($value)
     {
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->enable_upload)) {
-            $oldval = $config->form->first->enable_upload;
-        }
         $config->form->first->enable_upload = $value;
 
         $doc = $this->createTemporaryDoc();
@@ -524,13 +509,6 @@ class Publish_FormControllerTest extends ControllerTestCase
             ]);
 
         $this->dispatch('/publish/form/check');
-
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->enable_upload);
-        } else {
-            $config->form->first->enable_upload = $oldval;
-        }
     }
 
     private function addTemporaryTestDocument($session, $documentType)

--- a/tests/modules/publish/controllers/FormControllerTest.php
+++ b/tests/modules/publish/controllers/FormControllerTest.php
@@ -264,10 +264,6 @@ class Publish_FormControllerTest extends ControllerTestCase
     public function testOPUSVIER1886WithBibliography()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '1';
 
         $doc = $this->createTemporaryDoc();
@@ -288,13 +284,6 @@ class Publish_FormControllerTest extends ControllerTestCase
 
         $this->dispatch('/publish/form/check');
 
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
-
         $this->assertResponseCode(200);
         $this->assertContains('Bitte überprüfen Sie Ihre Eingaben.', $this->getResponse()->getBody());
         $this->assertContains('<legend>Bibliographie</legend>', $this->getResponse()->getBody());
@@ -304,10 +293,6 @@ class Publish_FormControllerTest extends ControllerTestCase
     public function testOPUSVIER1886WithBibliographyUnselected()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '1';
 
         $doc = $this->createTemporaryDoc();
@@ -330,13 +315,6 @@ class Publish_FormControllerTest extends ControllerTestCase
 
         $this->dispatch('/publish/form/check');
 
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
-
         $this->assertResponseCode(200);
         $this->assertContains('Bitte überprüfen Sie Ihre Eingaben.', $this->getResponse()->getBody());
         $this->assertContains('<legend>Bibliographie</legend>', $this->getResponse()->getBody());
@@ -346,10 +324,6 @@ class Publish_FormControllerTest extends ControllerTestCase
     public function testOPUSVIER1886WithBibliographySelected()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '1';
 
         $doc = $this->createTemporaryDoc();
@@ -372,13 +346,6 @@ class Publish_FormControllerTest extends ControllerTestCase
 
         $this->dispatch('/publish/form/check');
 
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
-
         $this->assertResponseCode(200);
         $this->assertContains('Bitte überprüfen Sie Ihre Eingaben.', $this->getResponse()->getBody());
         $this->assertContains('<legend>Bibliographie</legend>', $this->getResponse()->getBody());
@@ -391,10 +358,6 @@ class Publish_FormControllerTest extends ControllerTestCase
     public function testOPUSVIER1886WithoutBibliography()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '';
 
         $doc = $this->createTemporaryDoc();
@@ -415,13 +378,6 @@ class Publish_FormControllerTest extends ControllerTestCase
 
         $this->dispatch('/publish/form/check');
 
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
-
         $this->assertResponseCode(200);
         $this->assertContains('Bitte überprüfen Sie Ihre Eingaben.', $this->getResponse()->getBody());
         $this->assertNotContains('<legend>Bibliographie</legend>', $this->getResponse()->getBody());
@@ -435,10 +391,6 @@ class Publish_FormControllerTest extends ControllerTestCase
     {
         $this->markTestIncomplete('testing multipart formdata not yet solved');
         $config = Zend_Registry::get('Zend_Config');
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '';
 
         $this->request
@@ -454,13 +406,6 @@ class Publish_FormControllerTest extends ControllerTestCase
             ]);
         $this->dispatch('/publish/form/upload');
         $session = new Zend_Session_Namespace('Publish');
-
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
 
         $doc = new Opus_Document($session->documentId);
         $belongsToBibliography = $doc->getBelongsToBibliography();

--- a/tests/modules/publish/controllers/FormControllerTest.php
+++ b/tests/modules/publish/controllers/FormControllerTest.php
@@ -268,7 +268,7 @@ class Publish_FormControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 1;
+        $config->form->first->bibliographie = '1';
 
         $doc = $this->createTemporaryDoc();
 
@@ -308,7 +308,7 @@ class Publish_FormControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 1;
+        $config->form->first->bibliographie = '1';
 
         $doc = $this->createTemporaryDoc();
         $doc->setBelongsToBibliography(0);
@@ -350,7 +350,7 @@ class Publish_FormControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 1;
+        $config->form->first->bibliographie = '1';
 
         $doc = $this->createTemporaryDoc();
         $doc->setBelongsToBibliography(1);
@@ -395,7 +395,7 @@ class Publish_FormControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 0;
+        $config->form->first->bibliographie = '';
 
         $doc = $this->createTemporaryDoc();
 
@@ -439,7 +439,7 @@ class Publish_FormControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 0;
+        $config->form->first->bibliographie = '';
 
         $this->request
             ->setMethod('POST')
@@ -484,7 +484,7 @@ class Publish_FormControllerTest extends ControllerTestCase
 
     public function testDoNotShowFileNoticeOnSecondFormPageIfFileUploadIsDisabled()
     {
-        $this->fileNoticeOnSecondFormPage(0);
+        $this->fileNoticeOnSecondFormPage('');
 
         $this->assertContains('<h3 class="document-type" title="Dokumenttyp">Alle Felder (Testdokumenttyp)</h3>', $this->getResponse()->getBody());
         $this->assertNotContains('<legend>Sie haben folgende Datei(en) hochgeladen: </legend>', $this->getResponse()->getBody());
@@ -493,7 +493,7 @@ class Publish_FormControllerTest extends ControllerTestCase
 
     public function testDoNotShowFileNoticeOnThirdFormPageIfFileUploadIsDisabled()
     {
-        $this->fileNoticeOnThirdFormPage(0);
+        $this->fileNoticeOnThirdFormPage('');
 
         $this->assertResponseCode(200);
         $this->assertContains('Bitte überprüfen Sie Ihre Eingaben', $this->getResponse()->getBody());
@@ -503,7 +503,7 @@ class Publish_FormControllerTest extends ControllerTestCase
 
     public function testShowFileNoticeOnSecondFormPageIfFileUploadIsEnabled()
     {
-        $this->fileNoticeOnSecondFormPage(1);
+        $this->fileNoticeOnSecondFormPage('1');
 
         $this->assertContains('<h3 class="document-type" title="Dokumenttyp">Alle Felder (Testdokumenttyp)</h3>', $this->getResponse()->getBody());
         $this->assertContains('<legend>Sie haben folgende Datei(en) hochgeladen: </legend>', $this->getResponse()->getBody());
@@ -512,7 +512,7 @@ class Publish_FormControllerTest extends ControllerTestCase
 
     public function testShowFileNoticeOnThirdFormPageIfFileUploadIsEnabled()
     {
-        $this->fileNoticeOnThirdFormPage(1);
+        $this->fileNoticeOnThirdFormPage('1');
 
         $this->assertResponseCode(200);
         $this->assertContains('Bitte überprüfen Sie Ihre Eingaben', $this->getResponse()->getBody());

--- a/tests/modules/publish/controllers/IndexControllerTest.php
+++ b/tests/modules/publish/controllers/IndexControllerTest.php
@@ -59,22 +59,9 @@ class Publish_IndexControllerTest extends ControllerTestCase
     public function testShowFileUpload()
     {
         $config = Zend_Registry::get('Zend_Config');
-
-        // manipulate config
-        $oldval = null;
-        if (isset($config->form->first->enable_upload)) {
-            $oldval = $config->form->first->enable_upload;
-        }
         $config->form->first->enable_upload = '1';
 
         $this->dispatch('/publish');
-
-        // undo config changes before asserting anything
-        if (is_null($oldval)) {
-            unset($config->form->first->enable_upload);
-        } else {
-            $config->form->first->enable_upload = $oldval;
-        }
 
         $this->assertResponseCode(200);
         $this->assertController('index');
@@ -92,22 +79,9 @@ class Publish_IndexControllerTest extends ControllerTestCase
     public function testDoNotShowFileUpload()
     {
         $config = Zend_Registry::get('Zend_Config');
-
-        // manipulate config
-        $oldval = null;
-        if (isset($config->form->first->enable_upload)) {
-            $oldval = $config->form->first->enable_upload;
-        }
         $config->form->first->enable_upload = '';
 
         $this->dispatch('/publish');
-
-        // undo config changes
-        if (is_null($oldval)) {
-            unset($config->form->first->enable_upload);
-        } else {
-            $config->form->first->enable_upload = $oldval;
-        }
 
         $this->assertResponseCode(200);
         $this->assertController('index');
@@ -126,22 +100,9 @@ class Publish_IndexControllerTest extends ControllerTestCase
     public function testShowBibliographyCheckbox()
     {
         $config = Zend_Registry::get('Zend_Config');
-
-        // manipulate config
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '1';
 
         $this->dispatch('/publish');
-
-        // undo config changes before asserting anything
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
 
         $this->assertResponseCode(200);
         $this->assertController('index');
@@ -157,22 +118,9 @@ class Publish_IndexControllerTest extends ControllerTestCase
     public function testDoNotShowBibliographyCheckbox()
     {
         $config = Zend_Registry::get('Zend_Config');
-
-        // manipulate config
-        $oldval = null;
-        if (isset($config->form->first->bibliographie)) {
-            $oldval = $config->form->first->bibliographie;
-        }
         $config->form->first->bibliographie = '';
 
         $this->dispatch('/publish');
-
-        // undo config changes before asserting anything
-        if (is_null($oldval)) {
-            unset($config->form->first->bibliographie);
-        } else {
-            $config->form->first->bibliographie = $oldval;
-        }
 
         $this->assertResponseCode(200);
         $this->assertController('index');

--- a/tests/modules/publish/controllers/IndexControllerTest.php
+++ b/tests/modules/publish/controllers/IndexControllerTest.php
@@ -65,7 +65,7 @@ class Publish_IndexControllerTest extends ControllerTestCase
         if (isset($config->form->first->enable_upload)) {
             $oldval = $config->form->first->enable_upload;
         }
-        $config->form->first->enable_upload = 1;
+        $config->form->first->enable_upload = '1';
 
         $this->dispatch('/publish');
 
@@ -98,7 +98,7 @@ class Publish_IndexControllerTest extends ControllerTestCase
         if (isset($config->form->first->enable_upload)) {
             $oldval = $config->form->first->enable_upload;
         }
-        $config->form->first->enable_upload = 0;
+        $config->form->first->enable_upload = '';
 
         $this->dispatch('/publish');
 
@@ -132,7 +132,7 @@ class Publish_IndexControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 1;
+        $config->form->first->bibliographie = '1';
 
         $this->dispatch('/publish');
 
@@ -163,7 +163,7 @@ class Publish_IndexControllerTest extends ControllerTestCase
         if (isset($config->form->first->bibliographie)) {
             $oldval = $config->form->first->bibliographie;
         }
-        $config->form->first->bibliographie = 0;
+        $config->form->first->bibliographie = '';
 
         $this->dispatch('/publish');
 

--- a/tests/modules/publish/forms/PublishingFirstTest.php
+++ b/tests/modules/publish/forms/PublishingFirstTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
@@ -46,9 +45,9 @@ class Publish_Form_PublishingFirstTest extends ControllerTestCase
     public function testIsValidMethodWithMissingDocumentType()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->form->first->require_upload = 0;
-        $config->form->first->show_rights_checkbox = 0;
-        $config->form->first->bibliographie = 0;
+        $config->form->first->require_upload = '';
+        $config->form->first->show_rights_checkbox = '';
+        $config->form->first->bibliographie = '';
 
         $form = new Publish_Form_PublishingFirst(new Zend_View());
         $data = [
@@ -62,9 +61,9 @@ class Publish_Form_PublishingFirstTest extends ControllerTestCase
     public function testIsValidMethodWithMissingRightsCheckbox()
     {
         $config = Zend_Registry::get('Zend_Config');
-        $config->form->first->require_upload = 0;
-        $config->form->first->show_rights_checkbox = 1;
-        $config->form->first->bibliographie = 0;
+        $config->form->first->require_upload = '';
+        $config->form->first->show_rights_checkbox = '1';
+        $config->form->first->bibliographie = '';
 
         $form = new Publish_Form_PublishingFirst(new Zend_View());
         $data = [

--- a/tests/modules/rss/controllers/IndexControllerTest.php
+++ b/tests/modules/rss/controllers/IndexControllerTest.php
@@ -65,17 +65,11 @@ class Rss_IndexControllerTest extends ControllerTestCase
         $config = Zend_Registry::get('Zend_Config');
         $host = $config->searchengine->index->host;
         $port = $config->searchengine->index->port;
-        $oldValue = $config->searchengine->index->app;
         $config->searchengine->index->app = 'solr/corethatdoesnotexist';
         Zend_Registry::set('Zend_Config', $config);
 
         $this->dispatch('/rss/index/index/searchtype/all');
         $body = $this->getResponse()->getBody();
-
-        // restore configuration
-        $config = Zend_Registry::get('Zend_Config');
-        $config->searchengine->index->app = $oldValue;
-        Zend_Registry::set('Zend_Config', $config);
 
         $this->assertNotContains("http://${host}:${port}/solr/corethatdoesnotexist", $body);
         $this->assertContains("The search service is currently not available.", $body);

--- a/tests/modules/solrsearch/controllers/IndexControllerTest.php
+++ b/tests/modules/solrsearch/controllers/IndexControllerTest.php
@@ -656,7 +656,6 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
 
         $host = $config->searchengine->solr->default->service->default->endpoint->primary->host;
         $port = $config->searchengine->solr->default->service->default->endpoint->primary->port;
-        $oldValue = $config->searchengine->solr->default->service->default->endpoint->primary->path;
         $config->searchengine->solr->default->service->default->endpoint->primary->path = '/solr/corethatdoesnotexist';
         Zend_Registry::set('Zend_Config', $config);
 
@@ -666,11 +665,6 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
         $this->assertNotContains("http://${host}:${port}/solr/corethatdoesnotexist", $body);
         $this->assertContains('The search service is currently not available.', $body);
         $this->assertResponseCode(503);
-
-        // restore configuration
-        $config = Zend_Registry::get('Zend_Config');
-        $config->searchengine->solr->default->service->default->endpoint->primary->path = $oldValue;
-        Zend_Registry::set('Zend_Config', $config);
     }
 
     /**

--- a/tests/modules/solrsearch/controllers/IndexControllerTest.php
+++ b/tests/modules/solrsearch/controllers/IndexControllerTest.php
@@ -807,14 +807,14 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
 
         $this->dispatch('/solrsearch/index/search/searchtype/simple/query/facetlimittestwithsubjects-opusvier2610');
 
-        for ($index = 0; $index < $config->searchengine->solr->globalfacetlimit; $index++) {
+        for ($index = 0; $index < intval($config->searchengine->solr->globalfacetlimit); $index++) {
             $path = '/solrsearch/index/search/searchtype/simple/query/facetlimittestwithsubjects-opusvier2610/start/0/rows/10/subjectfq/subject';
             if ($index < 10) {
                 $path .= '0';
             }
             $this->assertContains($path . $index, $this->getResponse()->getBody());
         }
-        for ($index = $config->searchengine->solr->globalfacetlimit; $index < $numOfSubjects; $index++) {
+        for ($index = intval($config->searchengine->solr->globalfacetlimit); $index < $numOfSubjects; $index++) {
             $path = '/solrsearch/index/search/searchtype/simple/query/facetlimittestwithsubjects-opusvier2610/start/0/rows/10/subjectfq/subject';
             if ($index < 10) {
                 $path .= '0';

--- a/tests/modules/solrsearch/controllers/IndexControllerTest.php
+++ b/tests/modules/solrsearch/controllers/IndexControllerTest.php
@@ -803,7 +803,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
         $config = Zend_Registry::get('Zend_Config');
 
         $numOfSubjects = 20;
-        $doc = $this->addSampleDocWithMultipleSubjects($numOfSubjects);
+        $this->addSampleDocWithMultipleSubjects($numOfSubjects);
 
         $this->dispatch('/solrsearch/index/search/searchtype/simple/query/facetlimittestwithsubjects-opusvier2610');
 
@@ -831,11 +831,11 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
         if (isset($config->searchengine->solr->globalfacetlimit)) {
             $limit = $config->searchengine->solr->globalfacetlimit;
         }
-        $config->searchengine->solr->globalfacetlimit = 5;
+        $config->searchengine->solr->globalfacetlimit = '5';
         Zend_Registry::set('Zend_Config', $config);
 
         $numOfSubjects = 10;
-        $doc = $this->addSampleDocWithMultipleSubjects($numOfSubjects);
+        $this->addSampleDocWithMultipleSubjects($numOfSubjects);
 
         $this->dispatch('/solrsearch/index/search/searchtype/simple/query/facetlimittestwithsubjects-opusvier2610');
 
@@ -865,7 +865,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
                 'searchengine' => [
                     'solr' => [
                         'facetlimit' => [
-                            'subject' => 5]]]], true);
+                            'subject' => '5']]]], true);
             $oldConfig = Zend_Registry::get('Zend_Config');
             // Include the above made configuration changes in the application configuration.
             $config->merge(Zend_Registry::get('Zend_Config'));
@@ -873,7 +873,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
         Zend_Registry::set('Zend_Config', $config);
 
         $numOfSubjects = 10;
-        $doc = $this->addSampleDocWithMultipleSubjects($numOfSubjects);
+        $this->addSampleDocWithMultipleSubjects($numOfSubjects);
 
         $this->dispatch('/solrsearch/index/search/searchtype/simple/query/facetlimittestwithsubjects-opusvier2610');
 
@@ -1215,9 +1215,13 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
         $config->merge(new Zend_Config(['searchengine' =>
             ['solr' =>
                 ['facetlimit' =>
-                    ['author_facet' => 3,
-                          'year'         => 15]]]]));
-
+                    [
+                        'author_facet' => '3',
+                        'year' => '15'
+                    ]
+                ]
+            ]
+        ]));
         $this->dispatch('/solrsearch/index/search/searchtype/all/');
         $this->assertQueryContentContains("//div[@id='author_facet_facet']/div/a", ' + more');
         $this->assertQueryContentContains("//div[@id='year_facet']/div/a", ' + more');
@@ -1320,7 +1324,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
             'export' => ['stylesheet' => ['search' => 'example']],
-            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => 10]]
+            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => '10']]
         ]));
 
         $this->dispatch('/solrsearch/index/search/searchtype/latest');
@@ -1343,7 +1347,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
     public function testDisableEmptyCollectionsTrue()
     {
         Zend_Registry::get('Zend_Config')->merge(
-            new Zend_Config(['browsing' => ['disableEmptyCollections' => 1]])
+            new Zend_Config(['browsing' => ['disableEmptyCollections' => '1']])
         );
 
         $this->dispatch('/solrsearch/index/search/searchtype/collection/id/2');
@@ -1358,7 +1362,7 @@ class Solrsearch_IndexControllerTest extends ControllerTestCase
     public function testDisableEmptyCollectionsFalse()
     {
         Zend_Registry::get('Zend_Config')->merge(
-            new Zend_Config(['browsing' => ['disableEmptyCollections' => 0]])
+            new Zend_Config(['browsing' => ['disableEmptyCollections' => '']])
         );
 
         $this->dispatch('/solrsearch/index/search/searchtype/collection/id/2');

--- a/tests/modules/solrsearch/models/FacetMenuTest.php
+++ b/tests/modules/solrsearch/models/FacetMenuTest.php
@@ -31,7 +31,6 @@
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 
-
 class Solrsearch_Model_FacetMenuTest extends ControllerTestCase
 {
 
@@ -39,13 +38,18 @@ class Solrsearch_Model_FacetMenuTest extends ControllerTestCase
 
     public function testGetFacetLimitsFromConfig()
     {
-        $model = new Solrsearch_Model_FacetMenu();
+        new Solrsearch_Model_FacetMenu();
         $config = Zend_Registry::get('Zend_Config');
         $config->merge(new Zend_Config(['searchengine' =>
             ['solr' =>
                 ['facetlimit' =>
-                    ['author_facet' => 3,
-                        'year' => 15]]]]));
+                    [
+                        'author_facet' => '3',
+                        'year' => '15'
+                    ]
+                ]
+            ]
+        ]));
 
         $facetLimits = Opus_Search_Config::getFacetLimits();
 
@@ -60,7 +64,7 @@ class Solrsearch_Model_FacetMenuTest extends ControllerTestCase
 
     public function testGetFacetLimitsFromConfigWithYearInverted()
     {
-        $model = new Solrsearch_Model_FacetMenu();
+        new Solrsearch_Model_FacetMenu();
         $config = Zend_Registry::get('Zend_Config');
         if (isset($config->searchengine->solr->facets)) {
             $config->searchengine->solr->facets = 'year_inverted,doctype,author_facet,language,has_fulltext,belongs_to_bibliography,subject,institute';
@@ -75,8 +79,13 @@ class Solrsearch_Model_FacetMenuTest extends ControllerTestCase
         $config->merge(new Zend_Config(['searchengine' =>
             ['solr' =>
                 ['facetlimit' =>
-                    ['author_facet' => 3,
-                        'year_inverted' => 15]]]]));
+                    [
+                        'author_facet' => '3',
+                        'year_inverted' => '15'
+                    ]
+                ]
+            ]
+        ]));
 
         $facetLimits = Opus_Search_Config::getFacetLimits();
 

--- a/tests/modules/solrsearch/models/SearchTest.php
+++ b/tests/modules/solrsearch/models/SearchTest.php
@@ -111,7 +111,7 @@ class Solrsearch_Model_SearchTest extends ControllerTestCase
         $request = $this->getRequest();
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config([
-            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => 25]]
+            'searchengine' => ['solr' => ['numberOfDefaultSearchResults' => '25']]
         ]));
 
         $model = new Solrsearch_Model_Search();

--- a/tests/modules/solrsearch/models/search/BasicTest.php
+++ b/tests/modules/solrsearch/models/search/BasicTest.php
@@ -60,7 +60,7 @@ class Solrsearch_Model_Search_BasicTest extends ControllerTestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         $oldParamRows = $config->searchengine->solr->numberOfDefaultSearchResults;
-        $config->searchengine->solr->numberOfDefaultSearchResults = 1337;
+        $config->searchengine->solr->numberOfDefaultSearchResults = '1337';
 
         $request = $this->getRequest();
         $request->setParams(['searchtype' => 'all']);

--- a/tests/support/AssumptionChecker.php
+++ b/tests/support/AssumptionChecker.php
@@ -33,7 +33,6 @@
  * @author      Jens Schwidder <schwidder@zib.de>
  * @copyright   Copyright (c) 2008-2013, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
- * @version     $Id$
  */
 class AssumptionChecker
 {
@@ -62,7 +61,7 @@ class AssumptionChecker
 
         Zend_Registry::get('Zend_Config')->merge(new Zend_Config(
             ['searchengine' => ['solr' => [
-                'facetlimit' => ['year' => 10, 'year_inverted' => 10],
+                'facetlimit' => ['year' => '10', 'year_inverted' => '10'],
                 'facets' => 'year,doctype,author_facet,language,has_fulltext,belongs_to_bibliography,subject,institute'
             ]]]
         ));

--- a/tests/support/ControllerTestCase.php
+++ b/tests/support/ControllerTestCase.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * This file is part of OPUS. The software OPUS has been originally developed
  * at the University of Stuttgart with funding from the German Research Net,
  * the Federal Department of Higher Education and Research and the Ministry
@@ -39,7 +39,6 @@
  */
 class ControllerTestCase extends TestCase
 {
-
     const MESSAGE_LEVEL_NOTICE = 'notice';
 
     const MESSAGE_LEVEL_FAILURE = 'failure';
@@ -214,11 +213,13 @@ class ControllerTestCase extends TestCase
     {
         $adapter = new Opus_Security_AuthAdapter();
         $adapter->setCredentials($login, $password);
+
         $auth = Zend_Auth::getInstance();
-        $result = $auth->authenticate($adapter);
+        $auth->authenticate($adapter);
         $this->assertTrue($auth->hasIdentity());
+
         $config = Zend_Registry::get('Zend_Config');
-        if ($config->security) {
+        if (isset($config->security) && filter_var($config->security, FILTER_VALIDATE_BOOLEAN)) {
             Application_Security_AclProvider::init();
         }
     }
@@ -460,7 +461,7 @@ class ControllerTestCase extends TestCase
     {
         $config = Zend_Registry::get('Zend_Config');
         return (isset($config->tests->failTestOnMissingCommand) &&
-                $config->tests->failTestOnMissingCommand) ? true : false;
+                filter_var($config->tests->failTestOnMissingCommand, FILTER_VALIDATE_BOOLEAN));
     }
 
     /**
@@ -738,7 +739,7 @@ class ControllerTestCase extends TestCase
 
     public function assertSecurityConfigured()
     {
-        $this->assertEquals(1, Zend_Registry::get('Zend_Config')->security);
+        $this->assertEquals('1', Zend_Registry::get('Zend_Config')->security);
         $this->assertTrue(
             Zend_Registry::isRegistered('Opus_Acl'),
             'Expected registry key Opus_Acl to be set'


### PR DESCRIPTION
* Behandlung von booleschen Konfigurationsparametern verbessert durch Nutzung von `filter_var`
* In den Tests werden nur noch String-Literale als Konfigurationsparameter genutzt; keine Ints und keine Booleans

Um das Ticket OPUSVIER-4112 vollständig abzuschließen, muss noch die Behandlung von booleschen Konfigurationsparametern im "echten" Code geprüft werden. Dazu am besten von den Namen der Parameter in `application.ini` ausgehen.
