### PR TITLE
OPUSVIER-4298: Anpassungen nach Code Review

### DIFF
--- a/tests/library/Application/Import/ImporterTest.php
+++ b/tests/library/Application/Import/ImporterTest.php
@@ -68,9 +68,6 @@ class Application_Import_ImporterTest extends ControllerTestCase
 
         $this->setExpectedException(Application_Import_MetadataImportSkippedDocumentsException::class);
         $importer->run();
-
-        $document = $importer->getDocument();
-        $this->assertNull($document);
     }
 
     public function testValidEmbargoDate()


### PR DESCRIPTION
Zwei Zeilen im Test `testImportInvalidEmbargoDate` sind obsolet und wurden entfernt.