### PR TITLE
Bugfix of issue #373

### DIFF
--- a/public/layouts/default/common.phtml
+++ b/public/layouts/default/common.phtml
@@ -279,14 +279,14 @@ if ($dbprofiler->getEnabled() === true) : ?>
                         <?php if (is_null($queryCount)) {
                             // erste DB-Anweisung ist immer 'connect' - diese soll nicht ausgegeben werden; daher überspringen
                             $queryCount = 0;
-                            continue; }
-                        ?>
+                            continue;
+                        } ?>
                         <dd style="margin-inline-start: 0;"><?= ++$queryCount ?>:</dd>
                         <dt style="margin-inline-start: 1em;">
                             <?php if ($queryCount > $profiler_max_queries) {
                                 echo '...';
-                                break; }
-                            ?>
+                                break;
+                            } ?>
                             <pre><?= htmlspecialchars($value->getQuery()) ?></pre>
                         </dt>
                     <?php endforeach ?>

--- a/public/layouts/default/common.phtml
+++ b/public/layouts/default/common.phtml
@@ -273,16 +273,26 @@ if ($dbprofiler->getEnabled() === true) : ?>
             <b>Peak memory consumption: </b><?= memory_get_peak_usage(true) ?><br/>
             <?php if ($profiler_show_queries === true and $profiler_query_profiles = $dbprofiler->getQueryProfiles()) : ?>
                 <b>Queries:</b><br/>
-                <ul>
-                    <?php for ($i = 1; ($i < $profiler_max_queries) and ($i < count($profiler_query_profiles)); $i++) : ?>
-                        <li>
-                            <pre><?= htmlspecialchars($profiler_query_profiles[$i]->getQuery()) ?></pre>
-                        </li>
-                    <?php endfor ?>
-                    <?php if ($i < count($profiler_query_profiles)) : ?>
-                        <li>...</li>
-                    <?php endif ?>
-                </ul>
+                <dl>
+                    <?php $queryCount = null; ?>
+                    <?php foreach ($profiler_query_profiles as $value) : ?>
+                        <?php if (is_null($queryCount)) {
+                            // erste DB-Anweisung ist immer 'connect' - diese soll nicht ausgegeben werden; daher überspringen
+                            $queryCount = 0;
+                            continue;
+                        }
+                        ?>
+                        <dd style="margin-inline-start: 0;"><?= ++$queryCount ?>:</dd>
+                        <dt style="margin-inline-start: 1em;">
+                            <?php if ($queryCount > $profiler_max_queries) {
+                                echo '...';
+                                break;
+                            }
+                            ?>
+                            <pre><?= htmlspecialchars($value->getQuery()) ?></pre>
+                        </dt>
+                    <?php endforeach ?>
+                </dl>
             <?php endif ?>
         </div>
     </div>
@@ -297,7 +307,7 @@ if (isset($config->debugSession) and ((bool)$config->debugSession === true) and 
             <h2>Session</h2>
 
             <?php /* do not apply indentation here! */ ?>
-            <pre>
+<pre>
 <?= Zend_Debug::dump($_SESSION, 'Session Data', false); ?>
 </pre>
 

--- a/public/layouts/default/common.phtml
+++ b/public/layouts/default/common.phtml
@@ -279,15 +279,13 @@ if ($dbprofiler->getEnabled() === true) : ?>
                         <?php if (is_null($queryCount)) {
                             // erste DB-Anweisung ist immer 'connect' - diese soll nicht ausgegeben werden; daher überspringen
                             $queryCount = 0;
-                            continue;
-                        }
+                            continue; }
                         ?>
                         <dd style="margin-inline-start: 0;"><?= ++$queryCount ?>:</dd>
                         <dt style="margin-inline-start: 1em;">
                             <?php if ($queryCount > $profiler_max_queries) {
                                 echo '...';
-                                break;
-                            }
+                                break; }
                             ?>
                             <pre><?= htmlspecialchars($value->getQuery()) ?></pre>
                         </dt>

--- a/public/layouts/opus4/debug.phtml
+++ b/public/layouts/opus4/debug.phtml
@@ -22,14 +22,14 @@ if ($dbprofiler->getEnabled() === true) : ?>
                         <?php if (is_null($queryCount)) {
                             // erste DB-Anweisung ist immer 'connect' - diese soll nicht ausgegeben werden; daher überspringen
                             $queryCount = 0;
-                            continue; }
-                        ?>
+                            continue;
+                        } ?>
                         <dd style="margin-inline-start: 0;"><?= ++$queryCount ?>:</dd>
                         <dt style="margin-inline-start: 1em;">
                             <?php if ($queryCount > $profiler_max_queries) {
                                 echo '...';
-                                break; }
-                            ?>
+                                break;
+                            } ?>
                             <pre><?= htmlspecialchars($value->getQuery()) ?></pre>
                         </dt>
                     <?php endforeach ?>

--- a/public/layouts/opus4/debug.phtml
+++ b/public/layouts/opus4/debug.phtml
@@ -2,8 +2,7 @@
 $dbprofiler = \Zend_Registry::get('db_adapter')->getProfiler();
 $profiler_show_queries = isset($config->db->params->showqueries) && filter_var($config->db->params->showqueries, FILTER_VALIDATE_BOOLEAN);
 $profiler_max_queries = (int) $config->db->params->maxqueries;
-if ($dbprofiler->getEnabled() === true) :
-    ?>
+if ($dbprofiler->getEnabled() === true) : ?>
     <div class="debug dbprofiler">
         <div class="wrapper">
             <h2>Profiling information
@@ -11,20 +10,32 @@ if ($dbprofiler->getEnabled() === true) :
                     (execution time <?= microtime(true) - $GLOBALS['start_mtime'] ?>)
                 <?php endif ?>
             </h2>
-            <b>Total number of queries: </b><?= $dbprofiler->getTotalNumQueries() ?><br />
-            <b>Total query time (s): </b><?= $dbprofiler->getTotalElapsedSecs() ?><br />
-            <b>Current memory consumption: </b><?= memory_get_usage(true) ?><br />
-            <b>Peak memory consumption: </b><?= memory_get_peak_usage(true) ?><br />
+            <b>Total number of queries: </b><?= $dbprofiler->getTotalNumQueries() ?><br/>
+            <b>Total query time (s): </b><?= $dbprofiler->getTotalElapsedSecs() ?><br/>
+            <b>Current memory consumption: </b><?= memory_get_usage(true) ?><br/>
+            <b>Peak memory consumption: </b><?= memory_get_peak_usage(true) ?><br/>
             <?php if ($profiler_show_queries === true and $profiler_query_profiles = $dbprofiler->getQueryProfiles()) : ?>
-                <b>Queries:</b><br />
-                <ul>
-                    <?php for ($i = 1; ($i < $profiler_max_queries) and ($i < count($profiler_query_profiles)); $i++) : ?>
-                        <li><pre><?= htmlspecialchars($profiler_query_profiles[$i]->getQuery()) ?></pre></li>
-                    <?php endfor ?>
-                    <?php if ($i < count($profiler_query_profiles)) : ?>
-                        <li>...</li>
-                    <?php endif ?>
-                </ul>
+                <b>Queries:</b><br/>
+                <dl>
+                    <?php $queryCount = null; ?>
+                    <?php foreach ($profiler_query_profiles as $value) : ?>
+                        <?php if (is_null($queryCount)) {
+                            // erste DB-Anweisung ist immer 'connect' - diese soll nicht ausgegeben werden; daher überspringen
+                            $queryCount = 0;
+                            continue;
+                        }
+                        ?>
+                        <dd style="margin-inline-start: 0;"><?= ++$queryCount ?>:</dd>
+                        <dt style="margin-inline-start: 1em;">
+                            <?php if ($queryCount > $profiler_max_queries) {
+                                echo '...';
+                                break;
+                            }
+                            ?>
+                            <pre><?= htmlspecialchars($value->getQuery()) ?></pre>
+                        </dt>
+                    <?php endforeach ?>
+                </dl>
             <?php endif ?>
         </div>
     </div>

--- a/public/layouts/opus4/debug.phtml
+++ b/public/layouts/opus4/debug.phtml
@@ -22,15 +22,13 @@ if ($dbprofiler->getEnabled() === true) : ?>
                         <?php if (is_null($queryCount)) {
                             // erste DB-Anweisung ist immer 'connect' - diese soll nicht ausgegeben werden; daher überspringen
                             $queryCount = 0;
-                            continue;
-                        }
+                            continue; }
                         ?>
                         <dd style="margin-inline-start: 0;"><?= ++$queryCount ?>:</dd>
                         <dt style="margin-inline-start: 1em;">
                             <?php if ($queryCount > $profiler_max_queries) {
                                 echo '...';
-                                break;
-                            }
+                                break; }
                             ?>
                             <pre><?= htmlspecialchars($value->getQuery()) ?></pre>
                         </dt>


### PR DESCRIPTION
Dieser PR behebt den in #373 beschriebenen Fehler.

Mir ist nicht ganz klar, warum wir eine Code Duplication zwischen `common.phtml` und `debug.phtml` bezüglich des Debug-Outputs haben. Ich habe die Änderung jetzt erstmal an beiden Stellen eingebaut und auch kleine Unterschiede in der Formatierung entfernt. Jetzt stimmen die beiden Codeblöcke überein; man könnte vermutlich jetzt die Code Duplication gut auflösen.

@j3nsch , wenn Du mir sagst, welche der beiden Codestellen überleben soll, kann ich die Code Duplication gern noch in diesem PR auflösen.