### PR TITLE
OPUSVIER-1443

### DIFF
--- a/apacheconf/apache22.conf.template
+++ b/apacheconf/apache22.conf.template
@@ -50,7 +50,8 @@ Alias /OPUS_URL_BASE "/BASEDIR/public"
     php_flag short_open_tag on
 
     # Setting cookie options
-    php_value session.cookie_path    /OPUS_URL_BASE
+    php_value session.cookie_path     /OPUS_URL_BASE
+    php_value session.cookie_httponly on
 
     # On Debian/Ubuntu, prevent PHP from deleting the cookies
     #Enable for UBUNTU/DEBIAN:# php_value session.gc_probability 0

--- a/apacheconf/apache24.conf.template
+++ b/apacheconf/apache24.conf.template
@@ -48,7 +48,8 @@ Alias /OPUS_URL_BASE "/BASEDIR/public"
     php_flag short_open_tag on
 
     # Setting cookie options
-    php_value session.cookie_path    /OPUS_URL_BASE
+    php_value session.cookie_path     /OPUS_URL_BASE
+    php_value session.cookie_httponly on
 
     # On Debian/Ubuntu, prevent PHP from deleting the cookies
     #Enable for UBUNTU/DEBIAN:# php_value session.gc_probability 0


### PR DESCRIPTION
Die von der OPUS4-Webapp ausgestellten Cookies werden nun mit dem `HttpOnly`-Flag gesetzt, so dass der Client-Code (JavaScript) nicht mehr auf das Cookie zugreifen kann. 

Das Cookie wird weiterhin bei allen HTTP-Requests vom Client an den Server gesendet wird (darum kümmert sich der Browser), aber der clientseitig ausgeführte Code kann z.B. nicht mehr mittels `document.cookie` auf die in den Cookies gespeicherten Daten zugreifen. 

Damit wird die Anwendung robuster gegen XSS-Attacken (bei denen versucht wird die im Cookie gespeicherten Werte per clientseitig ausgeführtem JS an einen fremden Server zu senden, um so z.B. die Session des Nutzers übernehmen zu können).

Die Änderung müsste vermutlich in die Release Notes aufgenommen werden, da laufende Instanzen die Änderungen im Template nicht mitbekommen.