### PR TITLE
OPUSVIER-4493: Unterstützung des secure Cookie-Flag

### DIFF
--- a/apacheconf/apache22.conf.template
+++ b/apacheconf/apache22.conf.template
@@ -52,6 +52,7 @@ Alias /OPUS_URL_BASE "/BASEDIR/public"
     # Setting cookie options
     php_value session.cookie_path     /OPUS_URL_BASE
     php_value session.cookie_httponly on
+    php_value session.cookie_secure   off
 
     # On Debian/Ubuntu, prevent PHP from deleting the cookies
     #Enable for UBUNTU/DEBIAN:# php_value session.gc_probability 0

--- a/apacheconf/apache24.conf.template
+++ b/apacheconf/apache24.conf.template
@@ -50,6 +50,7 @@ Alias /OPUS_URL_BASE "/BASEDIR/public"
     # Setting cookie options
     php_value session.cookie_path     /OPUS_URL_BASE
     php_value session.cookie_httponly on
+    php_value session.cookie_secure   off
 
     # On Debian/Ubuntu, prevent PHP from deleting the cookies
     #Enable for UBUNTU/DEBIAN:# php_value session.gc_probability 0

--- a/bin/install-apache.sh
+++ b/bin/install-apache.sh
@@ -90,6 +90,12 @@ then
   sed -i -e 's!#Enable for UBUNTU/DEBIAN:# !!' "$OUTPUT_FILE"
 fi
 
+read -p 'Enable cookie flag "secure" (only applicable if OPUS installation uses HTTPS) [N]: ' ENABLE_SECURE_FLAG
+if [ "$ENABLE_SECURE_FLAG" = Y ] || [ "$ENABLE_SECURE_FLAG" = y ] ;
+then
+  sed -i -e 's!php_value session.cookie_secure   off!php_value session.cookie_secure   on!' "$OUTPUT_FILE"
+fi
+
 [ -z "$APACHE_ADD_SITE" ] && read -p "Add site to Apache2 [Y]: " APACHE_ADD_SITE
 
 if [ -z "$APACHE_ADD_SITE" ] || [ "$APACHE_ADD_SITE" = Y ] || [ "$APACHE_ADD_SITE" = y ] ;


### PR DESCRIPTION
Dieses Flag darf nur aktiviert werden, wenn die OPUS-Instanz via HTTPS erreichbar ist. Ansonsten legt der Browser keinen Cookie an (und die Anmeldung funktioniert dann z.B. nicht mehr).

Dieser PR sollte nach dem Merge von PR #379 begutachtet werden (ich habe die Änderungen von PR #379 als Ausgangspunkt für diesen PR verwendet, um spätere Merge-Konflikte zu vermeiden).

Vermutlich müsste die OPUS4-Doku ergänzt werden.