### PR TITLE
OPUSVIER-4140

### DIFF
--- a/modules/admin/forms/EnrichmentTable.php
+++ b/modules/admin/forms/EnrichmentTable.php
@@ -41,9 +41,9 @@ class Admin_Form_EnrichmentTable extends Application_Form_Model_Table
 {
     private $enrichmentKeys;
 
-    private $managedKeys = array();
+    private $managedKeys = [];
 
-    private $unmanagedKeys = array();
+    private $unmanagedKeys = [];
 
     public function init()
     {
@@ -131,8 +131,7 @@ class Admin_Form_EnrichmentTable extends Application_Form_Model_Table
         foreach ($models as $enrichmentKey) {
             if (is_null($enrichmentKey->getEnrichmentType())) {
                 $this->unmanagedKeys[] = $enrichmentKey;
-            }
-            else {
+            } else {
                 $this->managedKeys[] = $enrichmentKey;
             }
         }

--- a/modules/admin/forms/EnrichmentTable.php
+++ b/modules/admin/forms/EnrichmentTable.php
@@ -41,6 +41,10 @@ class Admin_Form_EnrichmentTable extends Application_Form_Model_Table
 {
     private $enrichmentKeys;
 
+    private $managedKeys = array();
+
+    private $unmanagedKeys = array();
+
     public function init()
     {
         $this->enrichmentKeys = new Admin_Model_EnrichmentKeys();
@@ -119,5 +123,28 @@ class Admin_Form_EnrichmentTable extends Application_Form_Model_Table
         }
 
         return "";
+    }
+
+    public function setModels($models)
+    {
+        parent::setModels($models);
+        foreach ($models as $enrichmentKey) {
+            if (is_null($enrichmentKey->getEnrichmentType())) {
+                $this->unmanagedKeys[] = $enrichmentKey;
+            }
+            else {
+                $this->managedKeys[] = $enrichmentKey;
+            }
+        }
+    }
+
+    public function getManaged()
+    {
+        return $this->managedKeys;
+    }
+
+    public function getUnmanaged()
+    {
+        return $this->unmanagedKeys;
     }
 }

--- a/modules/admin/views/scripts/enrichmentkey/enrichment.phtml
+++ b/modules/admin/views/scripts/enrichmentkey/enrichment.phtml
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @category    Application
+ * @package     Application_View_Scripts_EnrichmentKey
+ * @author      Sascha Szott <opus-development@saschaszott.de>
+ * @copyright   Copyright (c) 2008-2020, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+?>
+
+<table id="<?= $this->managed ? 'enrichmentkeyTableManaged' : 'enrichmentkeyTableUnmanaged' ?>">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <?PHP if ($this->managed) : ?>
+        <th>Typ</th>
+        <?PHP endif ?>
+        <th colspan="4"></th>
+    </tr>
+    </thead>
+    <tbody>
+        <?PHP foreach ($this->enrichments as $enrichment) : ?>
+        <tr class="<?= $this->element->getRowCssClass($enrichment)?>"
+            title="<?= htmlspecialchars($this->translate($this->element->getRowTooltip($enrichment))) ?>">
+            <td>
+                <?PHP if (is_null($enrichment->getId())) : ?>
+                    <?= htmlspecialchars($enrichment->getDisplayName()) ?>
+                <?PHP else : ?>
+                    <span class="strong">
+                        <?= htmlspecialchars($enrichment->getDisplayName()) ?>
+                    </span>
+                    <?PHP if ($this->element->isProtected($enrichment)) : ?>
+                        <i class="fa fa-lock"
+                           title="<?= htmlspecialchars($this->translate('admin_enrichmentkey_protected_tooltip')); ?>"
+                           aria-hidden="true"></i>
+                    <?PHP endif ?>
+                <?PHP endif ?>
+            </td>
+            <?PHP if ($this->managed) : ?>
+                <td>
+                    <?= htmlspecialchars($enrichment->getType()) ?>
+                    <?PHP $optionsPrintable = $enrichment->getOptionsPrintable();
+                    if (! is_null($optionsPrintable)) : ?>
+                        <i title="<?= htmlspecialchars($optionsPrintable) ?>" class="fa fa-info-circle" aria-hidden="true"></i>
+                    <?PHP endif ?>
+                </td>
+            <?PHP endif ?>
+            <td class="edit">
+                <?PHP if (is_null($enrichment->getId())) : ?>
+                    <a href="<?= $this->url(['action' => 'new', 'id' => $enrichment->getName()]) ?>"
+                    ><?= $this->translate('admin_button_create'); ?></a>
+                <?PHP elseif ($this->element->isModifiable($enrichment)) : ?>
+                    <a href="<?= $this->url(['action' => 'edit', 'id' => $enrichment->getId()]) ?>"
+                    ><?= $this->translate('admin_button_edit'); ?></a>
+                <?PHP endif ?>
+            </td>
+            <td class="remove">
+                <?PHP if (is_null($enrichment->getId())) : ?>
+                    <a href="<?= $this->url(['action' => 'removeFromDocs', 'id' => $enrichment->getName()]) ?>"
+                    ><?= $this->translate('admin_button_remove_from_documents'); ?></a>
+                <?PHP elseif ($this->element->isModifiable($enrichment) && $this->element->isUsed($enrichment)) : ?>
+                    <a href="<?= $this->url(['action' => 'removeFromDocs', 'id' => $enrichment->getId()]) ?>"
+                    ><?= $this->translate('admin_button_remove_from_documents'); ?></a>
+                <?PHP endif ?>
+            </td>
+            <td>
+                <?PHP if ($this->element->isModifiable($enrichment)) : ?>
+                    <a href="<?= $this->url([
+                        'module' => 'setup',
+                        'controller' => 'language',
+                        'action' => 'index',
+                        'search' => $enrichment->getName(),
+                        'scope' => 'key'
+                    ]) ?>"
+                    ><?= $this->translate('admin_button_translations'); ?></a>
+                <?PHP endif ?>
+            </td>
+            <td class="remove">
+                <?PHP if (! is_null($enrichment->getId()) && $this->element->isModifiable($enrichment)) : ?>
+                    <a href="<?= $this->url(['action' => 'delete', 'id' => $enrichment->getId()]) ?>"
+                    ><?= $this->translate('admin_button_remove'); ?></a>
+                <?PHP endif ?>
+            </td>
+        </tr>
+        <?PHP endforeach ?>
+    </tbody>
+</table>

--- a/modules/admin/views/scripts/enrichmentkey/enrichment.phtml
+++ b/modules/admin/views/scripts/enrichmentkey/enrichment.phtml
@@ -32,18 +32,19 @@
  */
 ?>
 
+<?PHP if (! is_null($this->enrichments) && ! empty($this->enrichments)) : ?>
 <table id="<?= $this->managed ? 'enrichmentkeyTableManaged' : 'enrichmentkeyTableUnmanaged' ?>">
     <thead>
     <tr>
         <th>Name</th>
         <?PHP if ($this->managed) : ?>
-        <th>Typ</th>
+            <th>Typ</th>
         <?PHP endif ?>
         <th colspan="4"></th>
     </tr>
     </thead>
     <tbody>
-        <?PHP foreach ($this->enrichments as $enrichment) : ?>
+    <?PHP foreach ($this->enrichments as $enrichment) : ?>
         <tr class="<?= $this->element->getRowCssClass($enrichment)?>"
             title="<?= htmlspecialchars($this->translate($this->element->getRowTooltip($enrichment))) ?>">
             <td>
@@ -51,8 +52,8 @@
                     <?= htmlspecialchars($enrichment->getDisplayName()) ?>
                 <?PHP else : ?>
                     <span class="strong">
-                        <?= htmlspecialchars($enrichment->getDisplayName()) ?>
-                    </span>
+                    <?= htmlspecialchars($enrichment->getDisplayName()) ?>
+                </span>
                     <?PHP if ($this->element->isProtected($enrichment)) : ?>
                         <i class="fa fa-lock"
                            title="<?= htmlspecialchars($this->translate('admin_enrichmentkey_protected_tooltip')); ?>"
@@ -106,6 +107,7 @@
                 <?PHP endif ?>
             </td>
         </tr>
-        <?PHP endforeach ?>
+    <?PHP endforeach ?>
     </tbody>
 </table>
+<?PHP endif ?>

--- a/modules/admin/views/scripts/enrichmentkey/modeltable.phtml
+++ b/modules/admin/views/scripts/enrichmentkey/modeltable.phtml
@@ -27,7 +27,7 @@
  * @category    Application
  * @package     Application_View_Scripts_EnrichmentKey
  * @author      Sascha Szott <opus-development@saschaszott.de>
- * @copyright   Copyright (c) 2008-2019, OPUS 4 development team
+ * @copyright   Copyright (c) 2008-2020, OPUS 4 development team
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
 ?>
@@ -36,79 +36,14 @@
     <?= $this->translate($this->element->getColumnLabel(0)) ?>
 </h2>
 <div class="enrichmentkey_new">
-    <a class="add" href="<?= $this->url(['action' => 'new']) ?>">
-        <?= $this->translate('admin_button_add') ?>
-    </a>
+    <a class="add" href="<?= $this->url(['action' => 'new']) ?>"><?= $this->translate('admin_button_add') ?></a>
 </div>
-<table id="enrichmentkeyTable">
-    <thead>
-    <tr>
-        <th>Name</th>
-        <th>Typ</th>
-        <th colspan="4"></th>
-    </tr>
-    </thead>
-    <?PHP foreach ($this->element->getModels() as $model) : ?>
-        <tr class="<?= $this->element->getRowCssClass($model)?>"
-            title="<?= htmlspecialchars($this->translate($this->element->getRowTooltip($model))) ?>">
-            <td>
-                <?php if (is_null($model->getId())) : ?>
-                    <?= htmlspecialchars($model->getDisplayName()) ?>
-                <?php else : ?>
-                    <span class="strong">
-                        <?= htmlspecialchars($model->getDisplayName()) ?>
-                    </span>
-                    <?PHP if ($this->element->isProtected($model)) : ?>
-                        <i class="fa fa-lock"
-                           title="<?= htmlspecialchars($this->translate('admin_enrichmentkey_protected_tooltip')); ?>"
-                           aria-hidden="true"></i>
-                    <?PHP endif ?>
-                <?php endif; ?>
-            </td>
-            <td>
-                <?= htmlspecialchars($model->getType()) ?>
-                <?PHP $optionsPrintable = $model->getOptionsPrintable();
-                if (! is_null($optionsPrintable)) : ?>
-                    <i title="<?= htmlspecialchars($optionsPrintable) ?>" class="fa fa-info-circle" aria-hidden="true"></i>
-                <?PHP endif ?>
-            </td>
-            <td class="edit">
-                <?PHP if (is_null($model->getId())) : ?>
-                    <a href="<?= $this->url(['action' => 'new', 'id' => $model->getName()]) ?>"
-                    ><?= $this->translate('admin_button_create'); ?></a>
-                <?PHP elseif ($this->element->isModifiable($model)) : ?>
-                    <a href="<?= $this->url(['action' => 'edit', 'id' => $model->getId()]) ?>"
-                    ><?= $this->translate('admin_button_edit'); ?></a>
-                <?PHP endif ?>
-            </td>
-            <td class="remove">
-                <?PHP if (is_null($model->getId())) : ?>
-                    <a href="<?= $this->url(['action' => 'removeFromDocs', 'id' => $model->getName()]) ?>"
-                    ><?= $this->translate('admin_button_remove_from_documents'); ?></a>
-                <?PHP elseif ($this->element->isModifiable($model) && $this->element->isUsed($model)) : ?>
-                    <a href="<?= $this->url(['action' => 'removeFromDocs', 'id' => $model->getId()]) ?>"
-                    ><?= $this->translate('admin_button_remove_from_documents'); ?></a>
-                <?PHP endif ?>
-            </td>
-            <td>
-                <?PHP if ($this->element->isModifiable($model)) : ?>
-                    <a href="<?= $this->url([
-                        'module' => 'setup',
-                        'controller' => 'language',
-                        'action' => 'index',
-                        'search' => $model->getName(),
-                        'scope' => 'key'
-                    ]) ?>"
-                    ><?= $this->translate('admin_button_translations'); ?></a>
-                <?PHP endif ?>
-            </td>
-            </td>
-            <td class="remove">
-                <?PHP if (! is_null($model->getId()) && $this->element->isModifiable($model)) : ?>
-                    <a href="<?= $this->url(['action' => 'delete', 'id' => $model->getId()]) ?>"
-                    ><?= $this->translate('admin_button_remove'); ?></a>
-                <?PHP endif ?>
-            </td>
-        </tr>
-    <?PHP endforeach; ?>
-</table>
+
+<?= $this->partial('enrichmentkey/enrichment.phtml', [
+        'managed' => true,
+        'enrichments' => $this->element->getManaged(),
+        'element' => $this->element]); ?>
+<?= $this->partial('enrichmentkey/enrichment.phtml', [
+        'managed' => false,
+        'enrichments' => $this->element->getUnmanaged(),
+        'element' => $this->element]); ?>

--- a/public/layouts/opus4/css/admin.css
+++ b/public/layouts/opus4/css/admin.css
@@ -2536,7 +2536,9 @@ a.create-document-link {
     float: right;
 }
 
-#enrichmentkeyTable span.strong {
+#enrichmentkeyTable span.strong,
+#enrichmentkeyTableManaged span.strong,
+#enrichmentkeyTableUnmanaged span.strong {
     font-weight: bold;
 }
 

--- a/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
+++ b/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
@@ -840,7 +840,8 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an protected css-class in enrichmentkeyTable
                 $this->assertXpathContentContains(
-                    '//table[@id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]', $value);
+                '//table[@id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
+                $value);
             }
         }
     }
@@ -860,8 +861,8 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an used css-class in enrichmentkeyTable
                 $this->assertXpathContentContains(
-                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'used\')]',
-                    $value);
+                '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'used\')]',
+                $value);
             }
         }
     }
@@ -882,8 +883,8 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an protected css-class in enrichmentkeyTable
                 $this->assertNotXpathContentContains(
-                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
-                    $value);
+                '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
+                $value);
             }
         }
     }
@@ -1311,8 +1312,7 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($textContent, 'unmanagedEKfirst') === 0) {
                 $foundFirst = true;
                 continue;
-            }
-            else if ($foundFirst) {
+            } else if ($foundFirst) {
                 if (strpos($textContent, 'unmanagedEKlast') === 0) {
                     $foundLast = true;
                 }
@@ -1376,8 +1376,7 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($textContent, 'managedEKfirst') === 0) {
                 $foundFirst = true;
                 continue;
-            }
-            else if ($foundFirst) {
+            } else if ($foundFirst) {
                 if (strpos($textContent, 'managedEKlast') === 0) {
                     $foundLast = true;
                 }

--- a/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
+++ b/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
@@ -907,8 +907,8 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an unused css-class in enrichmentkeyTable
                 $this->assertXpathContentContains(
-                        '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'unused\')]',
-                        $value
+                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'unused\')]',
+                    $value
                 );
             }
         }

--- a/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
+++ b/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
@@ -839,8 +839,8 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
         foreach ($protectedKeys as &$value) {
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an protected css-class in enrichmentkeyTable
-                $this->assertXpathContentContains('//table[@id="enrichmentkeyTable"]
-                //tr[contains(@class,\'protected\')]', $value);
+                $this->assertXpathContentContains(
+                    '//table[@id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]', $value);
             }
         }
     }
@@ -859,8 +859,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
         foreach ($usedKeys as &$value) {
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an used css-class in enrichmentkeyTable
-                $this->assertXpathContentContains('//table[@id="enrichmentkeyTable"]
-                //tr[contains(@class,\'used\')]', $value);
+                $this->assertXpathContentContains(
+                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'used\')]',
+                    $value);
             }
         }
     }
@@ -880,8 +881,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
         foreach ($unprotectedKeys as &$value) {
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an protected css-class in enrichmentkeyTable
-                $this->assertNotXpathContentContains('//table[@id="enrichmentkeyTable"]
-                //tr[contains(@class,\'protected\')]', $value);
+                $this->assertNotXpathContentContains(
+                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
+                    $value);
             }
         }
     }
@@ -900,8 +902,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
         foreach ($unusedKeys as &$value) {
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an unused css-class in enrichmentkeyTable
-                $this->assertXpathContentContains('//table[@id="enrichmentkeyTable"]
-                //tr[contains(@class,\'unused\')]', $value);
+                $this->assertXpathContentContains(
+                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'unused\')]',
+                    $value);
             }
         }
     }
@@ -1255,5 +1258,133 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             ['BibtexRecord'], // unreferenced enrichment key
             ['Audience']      // referenced enrichment key
         ];
+    }
+
+    /**
+     * Tests the function getUnmanaged()
+     *
+     * @covers ::getUnmanaged
+     */
+    public function testGetUnmanaged()
+    {
+        $this->dispatch($this->getControllerPath() . '/');
+
+        $this->assertResponseCode(200);
+
+        $domDoc = new DOMDocument();
+        $domDoc->loadHTML($this->getResponse()->getBody());
+        $xpath = new DOMXPath($domDoc);
+        $nodeList = $xpath->query('//table[@id="enrichmentkeyTableUnmanaged"]/tbody/tr');
+        $tableRowCount = $nodeList->length;
+
+        $enrichmentKeyLast = new EnrichmentKey();
+        $enrichmentKeyLast->setName('unmanagedEKlast');
+        $enrichmentKeyLast->store();
+
+        $enrichmentKeyFirst = new EnrichmentKey();
+        $enrichmentKeyFirst->setName('unmanagedEKfirst');
+        $enrichmentKeyFirst->store();
+
+        $this->getResponse()->clearBody();
+
+        $this->dispatch($this->getControllerPath() . '/');
+
+        $this->assertResponseCode(200);
+
+        // cleanup
+        $enrichmentKeyFirst->delete();
+        $enrichmentKeyLast->delete();
+
+        $domDoc = new DOMDocument();
+        $domDoc->loadHTML($this->getResponse()->getBody());
+        $xpath = new DOMXPath($domDoc);
+
+        // zwei neue Zeilen sollten in Tabelle für unmanaged EKs erscheinen
+        $nodeList = $xpath->query('//table[@id="enrichmentkeyTableUnmanaged"]/tbody/tr');
+        $this->assertEquals(2 + $tableRowCount, $nodeList->length);
+
+        // unmanagedEKfirst sollte direkt vor unmanagedEKlast erscheinen (in der Tabelle für unmanaged EKs)
+        $foundFirst = false;
+        $foundLast = false;
+        foreach ($nodeList as $node) {
+            $textContent = trim($node->textContent);
+            if (strpos($textContent, 'unmanagedEKfirst') === 0) {
+                $foundFirst = true;
+                continue;
+            }
+            else if ($foundFirst) {
+                if (strpos($textContent, 'unmanagedEKlast') === 0) {
+                    $foundLast = true;
+                }
+                break;
+            }
+        }
+        $this->assertTrue($foundFirst);
+        $this->assertTrue($foundLast);
+    }
+
+    /**
+     * Tests the function getManaged()
+     *
+     * @covers ::getManaged
+     */
+    public function testGetManaged()
+    {
+        $this->dispatch($this->getControllerPath() . '/');
+
+        $this->assertResponseCode(200);
+
+        $domDoc = new DOMDocument();
+        $domDoc->loadHTML($this->getResponse()->getBody());
+        $xpath = new DOMXPath($domDoc);
+        $nodeList = $xpath->query('//table[@id="enrichmentkeyTableManaged"]/tbody/tr');
+        $tableRowCount = $nodeList->length;
+
+        $enrichmentKeyLast = new EnrichmentKey();
+        $enrichmentKeyLast->setName('managedEKlast');
+        $enrichmentKeyLast->setType('TextType');
+        $enrichmentKeyLast->store();
+
+        $enrichmentKeyFirst = new EnrichmentKey();
+        $enrichmentKeyFirst->setName('managedEKfirst');
+        $enrichmentKeyFirst->setType('TextType');
+        $enrichmentKeyFirst->store();
+
+        $this->getResponse()->clearBody();
+
+        $this->dispatch($this->getControllerPath() . '/');
+
+        $this->assertResponseCode(200);
+
+        // cleanup
+        $enrichmentKeyFirst->delete();
+        $enrichmentKeyLast->delete();
+
+        $domDoc = new DOMDocument();
+        $domDoc->loadHTML($this->getResponse()->getBody());
+        $xpath = new DOMXPath($domDoc);
+
+        // zwei neue Zeilen sollten in Tabelle für managed EKs erscheinen
+        $nodeList = $xpath->query('//table[@id="enrichmentkeyTableManaged"]/tbody/tr');
+        $this->assertEquals(2 + $tableRowCount, $nodeList->length);
+
+        // managedEKfirst sollte direkt vor managedEKlast erscheinen (in der Tabelle für managed EKs)
+        $foundFirst = false;
+        $foundLast = false;
+        foreach ($nodeList as $node) {
+            $textContent = trim($node->textContent);
+            if (strpos($textContent, 'managedEKfirst') === 0) {
+                $foundFirst = true;
+                continue;
+            }
+            else if ($foundFirst) {
+                if (strpos($textContent, 'managedEKlast') === 0) {
+                    $foundLast = true;
+                }
+                break;
+            }
+        }
+        $this->assertTrue($foundFirst);
+        $this->assertTrue($foundLast);
     }
 }

--- a/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
+++ b/tests/modules/admin/controllers/EnrichmentkeyControllerTest.php
@@ -840,8 +840,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an protected css-class in enrichmentkeyTable
                 $this->assertXpathContentContains(
-                '//table[@id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
-                $value);
+                    '//table[@id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
+                    $value
+                );
             }
         }
     }
@@ -861,8 +862,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an used css-class in enrichmentkeyTable
                 $this->assertXpathContentContains(
-                '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'used\')]',
-                $value);
+                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'used\')]',
+                    $value
+                );
             }
         }
     }
@@ -883,8 +885,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an protected css-class in enrichmentkeyTable
                 $this->assertNotXpathContentContains(
-                '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
-                $value);
+                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'protected\')]',
+                    $value
+                );
             }
         }
     }
@@ -904,8 +907,9 @@ class Admin_EnrichmentkeyControllerTest extends CrudControllerTestCase
             if (strpos($response->getBody(), $value) !== false) {
                 // Xpath looks, if value has an unused css-class in enrichmentkeyTable
                 $this->assertXpathContentContains(
-                    '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'unused\')]',
-                    $value);
+                        '//table[@id="enrichmentkeyTableManaged" or @id="enrichmentkeyTableUnmanaged"]//tr[contains(@class,\'unused\')]',
+                        $value
+                );
             }
         }
     }


### PR DESCRIPTION
EKs, die einen Typ besitzen, werden von allen anderen EKs getrennt und es werden zwei Tabellen mit EKs angezeigt: zuerst die "managed" EKs (mit Typ); danach alle anderen EKs (unmanaged) - das sind sowohl System-EKs als auch EKs, die keinen Typ haben oder gar nicht registriert sind (sondern "nur" in Dokumenten verwendet werden)