### PR TITLE
Umbenennung der Konfigurationsoptionen in der Demo-Deckblattvorlage

### DIFF
--- a/application/configs/covers/demo-cover.md
+++ b/application/configs/covers/demo-cover.md
@@ -66,9 +66,9 @@ header-includes: |
   }
   \cohead{}
   \rohead{
-    \subsection{\hfill $repository-name$}
+    \subsection{\hfill $config-name$}
     \begin{minipage}[b]{0.30\textwidth}
-    \rightline{\small \url{$repository-url$}}
+    \rightline{\small \url{$config-url$}}
     \end{minipage}
   }
   \lofoot{

--- a/library/Application/Configuration.php
+++ b/library/Application/Configuration.php
@@ -268,7 +268,7 @@ class Application_Configuration extends Config
      */
     public function getValue($key)
     {
-        return parent::getValueFromConfig($this->getConfig(), $key);
+        return $this->getValueFromConfig($this->getConfig(), $key);
     }
 
     /**

--- a/library/Application/Configuration.php
+++ b/library/Application/Configuration.php
@@ -262,30 +262,6 @@ class Application_Configuration extends Config
     }
 
     /**
-     * Gets a value from a Zend_Config object.
-     *
-     * @param Zend_Config $config
-     * @param string      $option
-     * @return null|Zend_Config
-     */
-    public static function getValueFromConfig($config, $option)
-    {
-        if ($option === null || strlen(trim($option)) === 0) {
-            return null;
-        }
-
-        $keys      = explode('.', $option);
-        $subconfig = $config;
-        foreach ($keys as $key) {
-            $subconfig = $subconfig->get($key);
-            if (! $subconfig instanceof Zend_Config) {
-                break;
-            }
-        }
-        return $subconfig;
-    }
-
-    /**
      * Returns value for key in current configuration.
      *
      * @param string $key Name of option
@@ -293,42 +269,7 @@ class Application_Configuration extends Config
      */
     public function getValue($key)
     {
-        return self::getValueFromConfig($this->getConfig(), $key);
-    }
-
-    /**
-     * Updates a value in a Zend_Config object.
-     *
-     * @param Zend_Config $config
-     * @param string      $option Name of option
-     * @param string      $value New value for option
-     * @throws Zend_Exception
-     * TODO review and if possible replace this code with something simpler
-     */
-    public static function setValueInConfig($config, $option, $value)
-    {
-        if ($config->readOnly()) {
-             Log::get()->err('Zend_Config object is readonly.');
-            return;
-        }
-
-        $keys = explode('.', $option);
-
-        $subconfig = $config;
-
-        $index = 0;
-
-        foreach ($keys as $key) {
-            $index++;
-            if ($subconfig->get($key) === null && $index < count($keys)) {
-                // create subsection
-                eval('$subconfig->' . $key . ' = array();');
-                $subconfig = $subconfig->get($key);
-            } else {
-                // set value
-                eval('$subconfig->' . $key . ' = $value;');
-            }
-        }
+        return parent::getValueFromConfig($this->getConfig(), $key);
     }
 
     /**

--- a/library/Application/Configuration.php
+++ b/library/Application/Configuration.php
@@ -30,7 +30,6 @@
  */
 
 use Opus\Common\Config;
-use Opus\Common\Log;
 use Opus\Common\LoggingTrait;
 
 /**


### PR DESCRIPTION
Zweiter PR für #1036

Die Repository Metadaten `name` und `url` sind nun in Cover Templates als `config-name` und `config-url` verwendbar.

Siehe auch OPUS4/opus4-pdf#60