### PR TITLE
Update opus.css - add word break in titles

### DIFF
--- a/public/layouts/opus4/css/opus.css
+++ b/public/layouts/opus4/css/opus.css
@@ -1418,6 +1418,10 @@ a.gnd-link {
 
 /* MIME type icons */
 
+h2.titlemain {
+  word-break: break-all;
+}
+
 #download-fulltext li {
     margin-bottom: 1em;
 }


### PR DESCRIPTION
add word break if the title (h2) is too long