### PR TITLE
application.ini: fix typo in configuration key

### DIFF
--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -515,7 +515,7 @@ metatags.defaultMapping.book_part[]=bookpart
 
 ; Configuration of dcterms:DCMIType value for document types in XMetaDissPlus
 documentType.default.dcmiType = 'Text'
-docuemntType.default.dcType = 'Other'
+documentType.default.dcType = 'Other'
 documentType.diplthesis.dcType = 'masterThesis'
 documentType.diplom.dcType = 'masterThesis'
 documentType.habilitation.dcType = 'doctoralThesis'


### PR DESCRIPTION
This minor PR fixes a typo in `application.ini`.