### PR TITLE
Fix: dc:type im OpenAIRE-Set hat falsche Syntax nach Resume

### DIFF
--- a/modules/oai/models/Resumptiontoken.php
+++ b/modules/oai/models/Resumptiontoken.php
@@ -51,7 +51,7 @@ class Oai_Model_Resumptiontoken
     private $totalIds = 0;
 
     /** @var string Holds the set specification (if given) */
-    private $set = null;
+    private $set;
 
     /**
      *  Returns current holded document ids.

--- a/modules/oai/models/Resumptiontoken.php
+++ b/modules/oai/models/Resumptiontoken.php
@@ -50,6 +50,9 @@ class Oai_Model_Resumptiontoken
     /** @var int Holds total amount of document ids */
     private $totalIds = 0;
 
+    /** @var string Holds the set specification (if given) */
+    private $set = null;
+
     /**
      *  Returns current holded document ids.
      *
@@ -98,6 +101,16 @@ class Oai_Model_Resumptiontoken
     public function getTotalIds()
     {
         return $this->totalIds;
+    }
+
+    /**
+     * Returns the set specification.
+     *
+     * @return string|null
+     */
+    public function getSet()
+    {
+        return $this->set;
     }
 
     /**
@@ -152,5 +165,15 @@ class Oai_Model_Resumptiontoken
     public function setTotalIds($totalIds)
     {
         $this->totalIds = $totalIds;
+    }
+
+    /**
+     * Sets the set specification.
+     *
+     * @param string $set
+     */
+    public function setSet($set)
+    {
+        $this->set = $set;
     }
 }

--- a/modules/oai/models/Server.php
+++ b/modules/oai/models/Server.php
@@ -484,6 +484,11 @@ class Oai_Model_Server extends Application_Model_Abstract
             $metadataPrefix = $oaiRequest['metadataPrefix'];
         }
 
+        $set = null;
+        if (true === array_key_exists('set', $oaiRequest)) {
+            $set = $oaiRequest['set'];
+        }
+
         $tokenWorker = new Oai_Model_Resumptiontokens();
         $tokenWorker->setResumptionPath($tempPath);
 
@@ -503,11 +508,15 @@ class Oai_Model_Server extends Application_Model_Abstract
             $totalIds       = $token->getTotalIds();
             $restIds        = $token->getDocumentIds();
             $metadataPrefix = $token->getMetadataPrefix();
+            $set            = $token->getSet();
 
             $oaiRequest['metadataPrefix']     = $metadataPrefix;
             $oaiRequest['metadataPrefixMode'] = strtolower($metadataPrefix);
             $this->proc->setParameter('', 'oai_metadataPrefix', $metadataPrefix);
             $this->proc->setParameter('', 'oai_metadataPrefixMode', strtolower($metadataPrefix));
+            if ($set !== null) {
+                $this->proc->setParameter('', 'oai_set', $set);
+            }
             $resumed = true;
         } else {
             // no resumptionToken is given
@@ -543,6 +552,7 @@ class Oai_Model_Server extends Application_Model_Abstract
             $token->setTotalIds($totalIds);
             $token->setDocumentIds($restIds);
             $token->setMetadataPrefix($metadataPrefix);
+            $token->setSet($set);
 
             $tokenWorker->storeResumptionToken($token);
 


### PR DESCRIPTION
Laut [Doku](https://www.opus-repository.org/userdoc/features/openaire.html) bietet OPUS 4 die Möglichkeit, Dokumente über die OAI-Schnittstelle nach OpenAIRE 3.0 zu exportieren. Laut der [OpenAIRE v3-Doku](https://guidelines.openaire.eu/en/latest/literature/field_publicationtype.html) muß bei diesem Export das erste dc:type-Feld die Form "info:eu-repo/semantics/\<publication-type\>" haben. Dies ist beim Aufruf der ersten Trefferseite auch der Fall. Ab der zweiten Trefferseite aber fehlt der Präfix "info:eu-repo/semantics/", was z. B. zu Fehlern bei der Validierung bei OpenAIRE führt. Das Problem ist anscheinend, daß der Query-Parameter "set" nicht im Resume-Token gespeichert wird. Dieser PR enthält einen Vorschlag für einen Fix.